### PR TITLE
Add comprehensive Javadocs to all Java classes

### DIFF
--- a/src/main/java/ai/pipestream/schemamanager/config/OpenSearchClientProducer.java
+++ b/src/main/java/ai/pipestream/schemamanager/config/OpenSearchClientProducer.java
@@ -23,30 +23,115 @@ import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import javax.net.ssl.SSLContext;
 import java.util.Optional;
 
+/**
+ * CDI producer for OpenSearch client beans with configurable connection settings.
+ *
+ * <p>This producer creates and configures singleton instances of OpenSearch clients
+ * (both synchronous and asynchronous) with customizable connection parameters including
+ * multi-host support, authentication, SSL/TLS configuration, and timeouts.
+ *
+ * <p><strong>Configuration Properties:</strong>
+ * <ul>
+ *   <li><strong>opensearch.hosts</strong> - Comma-separated list of hosts (default: "localhost:9200")</li>
+ *   <li><strong>opensearch.protocol</strong> - Protocol to use: "http" or "https" (default: "http")</li>
+ *   <li><strong>opensearch.username</strong> - Optional basic auth username</li>
+ *   <li><strong>opensearch.password</strong> - Optional basic auth password</li>
+ *   <li><strong>opensearch.ssl.verify</strong> - Verify SSL certificates (default: true)</li>
+ *   <li><strong>opensearch.connection-timeout</strong> - Connection timeout in ms (default: 5000)</li>
+ *   <li><strong>opensearch.socket-timeout</strong> - Socket/response timeout in ms (default: 10000)</li>
+ * </ul>
+ *
+ * <p><strong>Features:</strong>
+ * <ul>
+ *   <li>Multi-host configuration for high availability</li>
+ *   <li>Basic authentication support</li>
+ *   <li>SSL/TLS with optional certificate verification bypass (for dev/test)</li>
+ *   <li>Configurable connection and socket timeouts</li>
+ *   <li>Connection pooling via Apache HttpClient 5</li>
+ * </ul>
+ *
+ * <p><strong>Security Warning:</strong><br>
+ * Setting {@code opensearch.ssl.verify=false} disables SSL certificate verification
+ * and should only be used in development/test environments with self-signed certificates.
+ *
+ * @author PipeStream.ai
+ * @version 1.0
+ * @see OpenSearchClient
+ * @see OpenSearchAsyncClient
+ */
 @ApplicationScoped
 public class OpenSearchClientProducer {
 
+    /**
+     * Comma-separated list of OpenSearch hosts (e.g., "host1:9200,host2:9200").
+     * Defaults to "localhost:9200".
+     */
     @ConfigProperty(name = "opensearch.hosts", defaultValue = "localhost:9200")
     String hosts;
 
+    /**
+     * Protocol to use for OpenSearch connections ("http" or "https").
+     * Defaults to "http".
+     */
     @ConfigProperty(name = "opensearch.protocol", defaultValue = "http")
     String protocol;
 
+    /**
+     * Optional username for basic authentication.
+     * If present and non-blank, basic auth will be configured.
+     */
     @ConfigProperty(name = "opensearch.username")
     Optional<String> username;
 
+    /**
+     * Optional password for basic authentication.
+     * Used in conjunction with username.
+     */
     @ConfigProperty(name = "opensearch.password")
     Optional<String> password;
 
+    /**
+     * Whether to verify SSL certificates when using HTTPS.
+     * Set to false to disable verification (development/test only).
+     * Defaults to true.
+     */
     @ConfigProperty(name = "opensearch.ssl.verify", defaultValue = "true")
     boolean sslVerify;
 
+    /**
+     * Connection timeout in milliseconds.
+     * Maximum time to wait for connection establishment.
+     * Defaults to 5000ms (5 seconds).
+     */
     @ConfigProperty(name = "opensearch.connection-timeout", defaultValue = "5000")
     int connectTimeout;
 
+    /**
+     * Socket/response timeout in milliseconds.
+     * Maximum time to wait for a response after sending a request.
+     * Defaults to 10000ms (10 seconds).
+     */
     @ConfigProperty(name = "opensearch.socket-timeout", defaultValue = "10000")
     int socketTimeout;
 
+    /**
+     * Produces a configured Apache HttpClient 5 transport for OpenSearch.
+     *
+     * <p>This method creates the underlying HTTP transport layer used by both
+     * synchronous and asynchronous OpenSearch clients. The transport is configured with:
+     * <ul>
+     *   <li>Multiple hosts for failover and load balancing</li>
+     *   <li>Basic authentication credentials (if provided)</li>
+     *   <li>SSL/TLS configuration with optional certificate verification bypass</li>
+     *   <li>Connection and socket timeouts</li>
+     *   <li>Jackson JSON mapper for request/response serialization</li>
+     * </ul>
+     *
+     * <p>The transport is created as a singleton and shared by all OpenSearch clients.
+     *
+     * @return a configured ApacheHttpClient5Transport instance
+     * @throws RuntimeException if transport creation fails (e.g., SSL setup error)
+     */
     @Produces
     @Singleton
     public ApacheHttpClient5Transport openSearchTransport() {
@@ -95,12 +180,42 @@ public class OpenSearchClientProducer {
         }
     }
 
+    /**
+     * Produces a synchronous OpenSearch client for blocking operations.
+     *
+     * <p>This client is suitable for:
+     * <ul>
+     *   <li>Index management operations (create, delete, get mappings)</li>
+     *   <li>Synchronous indexing in worker threads</li>
+     *   <li>Administrative operations</li>
+     * </ul>
+     *
+     * <p>The client is created as a singleton and uses the shared transport.
+     *
+     * @param transport the Apache HttpClient 5 transport to use
+     * @return a configured synchronous OpenSearchClient
+     */
     @Produces
     @Singleton
     public OpenSearchClient openSearchClient(ApacheHttpClient5Transport transport) {
         return new OpenSearchClient(transport);
     }
 
+    /**
+     * Produces an asynchronous OpenSearch client for non-blocking operations.
+     *
+     * <p>This client is suitable for:
+     * <ul>
+     *   <li>High-throughput indexing operations</li>
+     *   <li>Search queries in reactive pipelines</li>
+     *   <li>Operations requiring CompletableFuture-based async execution</li>
+     * </ul>
+     *
+     * <p>The client is created as a singleton and uses the shared transport.
+     *
+     * @param transport the Apache HttpClient 5 transport to use
+     * @return a configured asynchronous OpenSearchAsyncClient
+     */
     @Produces
     @Singleton
     public OpenSearchAsyncClient openSearchAsyncClient(ApacheHttpClient5Transport transport) {

--- a/src/main/java/ai/pipestream/schemamanager/kafka/RepositoryUpdateConsumer.java
+++ b/src/main/java/ai/pipestream/schemamanager/kafka/RepositoryUpdateConsumer.java
@@ -19,19 +19,75 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.jboss.logging.Logger;
 
 /**
- * Consumes repository update notifications from Kafka and indexes them in OpenSearch
+ * Kafka consumer for repository update notifications with OpenSearch indexing.
+ *
+ * <p>This service consumes update notifications from multiple Kafka topics and
+ * maintains the OpenSearch indices in sync with repository state changes. It acts
+ * as the primary integration point between the Kafka event stream and the OpenSearch
+ * indexing layer.
+ *
+ * <p><strong>Consumed Kafka Topics:</strong>
+ * <ul>
+ *   <li><strong>drive-updates-in</strong> - Filesystem drive create/update/delete events</li>
+ *   <li><strong>repository-document-events-in</strong> - Document change events (requires gRPC fetch)</li>
+ *   <li><strong>module-updates-in</strong> - Module definition changes</li>
+ *   <li><strong>pipedoc-updates-in</strong> - PipeDoc metadata updates</li>
+ *   <li><strong>process-request-updates-in</strong> - Process request creation/updates</li>
+ *   <li><strong>process-response-updates-in</strong> - Process response updates</li>
+ *   <li><strong>graph-updates-in</strong> - Pipeline graph structure changes</li>
+ * </ul>
+ *
+ * <p><strong>Update Type Handling:</strong><br>
+ * Each notification includes an update type that determines the action:
+ * <ul>
+ *   <li><strong>CREATED/UPDATED</strong> - Index or re-index the entity</li>
+ *   <li><strong>DELETED</strong> - Remove the entity from the index</li>
+ * </ul>
+ *
+ * <p><strong>Error Handling:</strong><br>
+ * All indexing errors are logged but do not prevent message acknowledgment, ensuring
+ * Kafka consumer progress. Failed indexing operations can be retried through
+ * re-publishing or manual re-indexing.
+ *
+ * <p><strong>Special Case - Document Events:</strong><br>
+ * Document events contain minimal information (document ID and account ID) and require
+ * a gRPC call to the repository service to fetch full metadata before indexing. The
+ * payload is excluded to reduce memory and network overhead.
+ *
+ * @author PipeStream.ai
+ * @version 1.0
+ * @see OpenSearchIndexingService
+ * @see GrpcClientProvider
  */
 @ApplicationScoped
 public class RepositoryUpdateConsumer {
-    
+
     private static final Logger LOG = Logger.getLogger(RepositoryUpdateConsumer.class);
-    
+
+    /**
+     * OpenSearch indexing service for performing index and delete operations.
+     * Injected via CDI.
+     */
     @Inject
     OpenSearchIndexingService indexingService;
 
+    /**
+     * Dynamic gRPC client provider for calling repository services.
+     * Used to fetch full node metadata when processing document events.
+     * Injected via CDI.
+     */
     @Inject
     GrpcClientProvider grpcClientProvider;
     
+    /**
+     * Consumes drive update notifications from Kafka and indexes them in OpenSearch.
+     *
+     * <p>This method handles CREATED, UPDATED, and DELETED events for filesystem drives.
+     * Drive updates include configuration changes for storage endpoints (S3, local, etc.).
+     *
+     * @param message the Kafka message containing the DriveUpdateNotification
+     * @return a {@link Uni} that completes after indexing and message acknowledgment
+     */
     @Incoming("drive-updates-in")
     public Uni<Void> consumeDriveUpdate(Message<DriveUpdateNotification> message) {
         DriveUpdateNotification notification = message.getPayload();
@@ -52,6 +108,22 @@ public class RepositoryUpdateConsumer {
         });
     }
     
+    /**
+     * Consumes repository document events and indexes node metadata in OpenSearch.
+     *
+     * <p>This method handles document change events by:
+     * <ol>
+     *   <li>Receiving a lightweight event with document ID and account ID</li>
+     *   <li>Making a gRPC call to the repository service to fetch full node metadata</li>
+     *   <li>Indexing the node metadata (without payload) in OpenSearch</li>
+     * </ol>
+     *
+     * <p>The metadata-only fetch (includePayload=false) reduces network overhead while
+     * providing sufficient information for search and discovery.
+     *
+     * @param message the Kafka message containing the RepositoryEvent
+     * @return a {@link Uni} that completes after fetching, indexing, and message acknowledgment
+     */
     @Incoming("repository-document-events-in")
     public Uni<Void> consumeDocumentEvent(Message<RepositoryEvent> message) {
         RepositoryEvent event = message.getPayload();
@@ -83,6 +155,15 @@ public class RepositoryUpdateConsumer {
         });
     }
     
+    /**
+     * Consumes module update notifications and indexes them in OpenSearch.
+     *
+     * <p>This method handles CREATED, UPDATED, and DELETED events for processing modules.
+     * Modules define the processing capabilities available in the pipeline system.
+     *
+     * @param message the Kafka message containing the ModuleUpdateNotification
+     * @return a {@link Uni} that completes after indexing and message acknowledgment
+     */
     @Incoming("module-updates-in")
     public Uni<Void> consumeModuleUpdate(Message<ModuleUpdateNotification> message) {
         ModuleUpdateNotification notification = message.getPayload();
@@ -103,6 +184,15 @@ public class RepositoryUpdateConsumer {
         });
     }
     
+    /**
+     * Consumes PipeDoc update notifications and indexes them in OpenSearch.
+     *
+     * <p>This method handles CREATED, UPDATED, and DELETED events for PipeDoc documents,
+     * which contain document metadata, tags, and potentially embeddings for semantic search.
+     *
+     * @param message the Kafka message containing the PipeDocUpdateNotification
+     * @return a {@link Uni} that completes after indexing and message acknowledgment
+     */
     @Incoming("pipedoc-updates-in")
     public Uni<Void> consumePipeDocUpdate(Message<PipeDocUpdateNotification> message) {
         PipeDocUpdateNotification notification = message.getPayload();
@@ -123,6 +213,15 @@ public class RepositoryUpdateConsumer {
         });
     }
     
+    /**
+     * Consumes process request update notifications and indexes them in OpenSearch.
+     *
+     * <p>This method handles CREATED, UPDATED, and DELETED events for process requests,
+     * which represent pipeline execution requests with input parameters.
+     *
+     * @param message the Kafka message containing the ProcessRequestUpdateNotification
+     * @return a {@link Uni} that completes after indexing and message acknowledgment
+     */
     @Incoming("process-request-updates-in")
     public Uni<Void> consumeProcessRequestUpdate(Message<ProcessRequestUpdateNotification> message) {
         ProcessRequestUpdateNotification notification = message.getPayload();
@@ -143,6 +242,15 @@ public class RepositoryUpdateConsumer {
         });
     }
     
+    /**
+     * Consumes process response update notifications and indexes them in OpenSearch.
+     *
+     * <p>This method handles CREATED, UPDATED, and DELETED events for process responses,
+     * which contain the results and status of pipeline executions.
+     *
+     * @param message the Kafka message containing the ProcessResponseUpdateNotification
+     * @return a {@link Uni} that completes after indexing and message acknowledgment
+     */
     @Incoming("process-response-updates-in")
     public Uni<Void> consumeProcessResponseUpdate(Message<ProcessResponseUpdateNotification> message) {
         ProcessResponseUpdateNotification notification = message.getPayload();
@@ -163,6 +271,22 @@ public class RepositoryUpdateConsumer {
         });
     }
     
+    /**
+     * Consumes graph update notifications and indexes graph components in OpenSearch.
+     *
+     * <p>This method handles updates for pipeline graph structures, including:
+     * <ul>
+     *   <li><strong>Graph</strong> - Complete graph metadata with node/edge counts</li>
+     *   <li><strong>GraphNode</strong> - Individual processing nodes in the graph</li>
+     *   <li><strong>GraphEdge</strong> - Connections between nodes with routing logic</li>
+     * </ul>
+     *
+     * <p>The notification payload indicates which component type to index by using
+     * protobuf oneof fields (hasGraph(), hasNode(), hasEdge()).
+     *
+     * @param message the Kafka message containing the GraphUpdateNotification
+     * @return a {@link Uni} that completes after indexing and message acknowledgment
+     */
     @Incoming("graph-updates-in")
     public Uni<Void> consumeGraphUpdate(Message<GraphUpdateNotification> message) {
         GraphUpdateNotification notification = message.getPayload();
@@ -189,7 +313,28 @@ public class RepositoryUpdateConsumer {
         });
     }
     
-    private Uni<Void> processUpdate(String updateType, 
+    /**
+     * Processes an update notification by routing to the appropriate index or delete action.
+     *
+     * <p>This helper method implements the common pattern for handling CREATED, UPDATED,
+     * and DELETED events across all entity types.
+     *
+     * <p><strong>Routing logic:</strong>
+     * <ul>
+     *   <li><strong>CREATED/UPDATED</strong> - Executes createOrUpdateAction (index operation)</li>
+     *   <li><strong>DELETED</strong> - Executes deleteAction (delete operation)</li>
+     *   <li><strong>Unknown</strong> - Logs warning and returns successfully (no-op)</li>
+     * </ul>
+     *
+     * <p>All failures are logged with the entity description for troubleshooting.
+     *
+     * @param updateType the update type string ("CREATED", "UPDATED", "DELETED")
+     * @param createOrUpdateAction supplier for the index operation
+     * @param deleteAction supplier for the delete operation
+     * @param entityDescription human-readable entity description for logging (e.g., "drive my-drive")
+     * @return a {@link Uni} that completes after executing the appropriate action
+     */
+    private Uni<Void> processUpdate(String updateType,
                                     java.util.function.Supplier<Uni<Void>> createOrUpdateAction,
                                     java.util.function.Supplier<Uni<Void>> deleteAction,
                                     String entityDescription) {

--- a/src/main/java/ai/pipestream/schemamanager/opensearch/IndexConstants.java
+++ b/src/main/java/ai/pipestream/schemamanager/opensearch/IndexConstants.java
@@ -1,12 +1,43 @@
 package ai.pipestream.schemamanager.opensearch;
 
 /**
- * Constants for OpenSearch indices and field names
+ * Centralized constants for OpenSearch index names and field names.
+ *
+ * <p>This class provides type-safe enums for all OpenSearch indices and their
+ * field names used throughout the application. Using these constants ensures
+ * consistency across indexing, querying, and mapping operations.
+ *
+ * <p><strong>Benefits:</strong>
+ * <ul>
+ *   <li>Single source of truth for index and field names</li>
+ *   <li>Compile-time safety (no typos in string literals)</li>
+ *   <li>IDE autocomplete support</li>
+ *   <li>Easy refactoring and renaming</li>
+ * </ul>
+ *
+ * <p>The class is organized into multiple enums, each representing a different
+ * scope of constants:
+ * <ul>
+ *   <li>{@link Index} - OpenSearch index names</li>
+ *   <li>{@link CommonFields} - Fields used across all/most indices</li>
+ *   <li>{@link DriveFields} - Filesystem drive-specific fields</li>
+ *   <li>{@link NodeFields} - Filesystem node-specific fields</li>
+ *   <li>{@link PipeDocFields} - PipeDoc document-specific fields</li>
+ *   <li>{@link ProcessFields} - Process request/response fields</li>
+ *   <li>{@link GraphFields} - Pipeline graph-specific fields</li>
+ *   <li>{@link ModuleFields} - Module definition fields</li>
+ * </ul>
+ *
+ * @author PipeStream.ai
+ * @version 1.0
  */
 public class IndexConstants {
-    
+
     /**
-     * Index names for different entity types
+     * OpenSearch index names for different entity types.
+     *
+     * <p>This enum defines all indices used by the application, organized by
+     * functional area (filesystem, repository, graphs).
      */
     public enum Index {
         // Filesystem indices
@@ -27,14 +58,22 @@ public class IndexConstants {
         Index(String indexName) {
             this.indexName = indexName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch index name.
+         *
+         * @return the index name string (e.g., "filesystem-drives")
+         */
         public String getIndexName() {
             return indexName;
         }
     }
     
     /**
-     * Common field names across all indices
+     * Common field names used across multiple indices.
+     *
+     * <p>These fields represent standard attributes that most entities share,
+     * such as identifiers, timestamps, and metadata.
      */
     public enum CommonFields {
         ID("id"),
@@ -52,14 +91,22 @@ public class IndexConstants {
         CommonFields(String fieldName) {
             this.fieldName = fieldName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch field name.
+         *
+         * @return the field name string (e.g., "created_at")
+         */
         public String getFieldName() {
             return fieldName;
         }
     }
     
     /**
-     * Drive-specific field names
+     * Field names specific to the filesystem-drives index.
+     *
+     * <p>These fields describe storage drive configurations including S3 settings,
+     * encryption, versioning, and access control.
      */
     public enum DriveFields {
         DRIVE_NAME("drive_name"),
@@ -82,14 +129,29 @@ public class IndexConstants {
         DriveFields(String fieldName) {
             this.fieldName = fieldName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch field name.
+         *
+         * @return the field name string (e.g., "bucket")
+         */
         public String getFieldName() {
             return fieldName;
         }
     }
     
     /**
-     * Node-specific field names
+     * Field names specific to the filesystem-nodes index.
+     *
+     * <p>These fields describe files and folders with comprehensive metadata including:
+     * <ul>
+     *   <li>Hierarchical path information (path, components, depth)</li>
+     *   <li>Size metrics (file, payload, metadata, total)</li>
+     *   <li>S3/storage details (bucket, key, etag, version)</li>
+     *   <li>File metadata (MIME type, extension, category)</li>
+     *   <li>Payload information (type, class, size)</li>
+     *   <li>UI/display fields (icon, service type)</li>
+     * </ul>
      */
     public enum NodeFields {
         NODE_ID("node_id"),
@@ -143,14 +205,22 @@ public class IndexConstants {
         NodeFields(String fieldName) {
             this.fieldName = fieldName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch field name.
+         *
+         * @return the field name string (e.g., "path_components")
+         */
         public String getFieldName() {
             return fieldName;
         }
     }
     
     /**
-     * PipeDoc-specific field names
+     * Field names specific to the repository-pipedocs index.
+     *
+     * <p>These fields describe PipeDoc documents which contain processed document
+     * metadata, embeddings, and extracted entities.
      */
     public enum PipeDocFields {
         STORAGE_ID("storage_id"),
@@ -166,14 +236,22 @@ public class IndexConstants {
         PipeDocFields(String fieldName) {
             this.fieldName = fieldName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch field name.
+         *
+         * @return the field name string (e.g., "storage_id")
+         */
         public String getFieldName() {
             return fieldName;
         }
     }
     
     /**
-     * Process Request/Response field names
+     * Field names for process request and response indices.
+     *
+     * <p>These fields describe pipeline execution requests and their corresponding
+     * responses, linking them to modules, processors, and streams.
      */
     public enum ProcessFields {
         STORAGE_ID("storage_id"),
@@ -189,14 +267,22 @@ public class IndexConstants {
         ProcessFields(String fieldName) {
             this.fieldName = fieldName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch field name.
+         *
+         * @return the field name string (e.g., "request_id")
+         */
         public String getFieldName() {
             return fieldName;
         }
     }
     
     /**
-     * Graph-specific field names
+     * Field names for pipeline graph indices (graphs, nodes, edges).
+     *
+     * <p>These fields describe the structure and connections of pipeline graphs,
+     * including graph metadata, node configurations, and edge routing logic.
      */
     public enum GraphFields {
         GRAPH_ID("graph_id"),
@@ -219,14 +305,22 @@ public class IndexConstants {
         GraphFields(String fieldName) {
             this.fieldName = fieldName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch field name.
+         *
+         * @return the field name string (e.g., "graph_id")
+         */
         public String getFieldName() {
             return fieldName;
         }
     }
     
     /**
-     * Module-specific field names
+     * Field names specific to the repository-modules index.
+     *
+     * <p>These fields describe processing module definitions including their
+     * implementation details, gRPC interfaces, and configuration schemas.
      */
     public enum ModuleFields {
         MODULE_ID("module_id"),
@@ -241,7 +335,12 @@ public class IndexConstants {
         ModuleFields(String fieldName) {
             this.fieldName = fieldName;
         }
-        
+
+        /**
+         * Returns the actual OpenSearch field name.
+         *
+         * @return the field name string (e.g., "module_id")
+         */
         public String getFieldName() {
             return fieldName;
         }

--- a/src/main/java/ai/pipestream/schemamanager/opensearch/OpenSearchSchemaService.java
+++ b/src/main/java/ai/pipestream/schemamanager/opensearch/OpenSearchSchemaService.java
@@ -4,26 +4,68 @@ import ai.pipestream.opensearch.v1.VectorFieldDefinition;
 import io.smallrye.mutiny.Uni;
 
 /**
- * A reactive client interface for interacting with OpenSearch index mappings.
+ * Service interface for managing OpenSearch index schemas and mappings.
+ *
+ * <p>This interface defines operations for checking and creating index mappings,
+ * specifically focused on nested field structures used for storing vector embeddings.
+ *
+ * <p>All operations are reactive and return {@link Uni} types for non-blocking execution.
+ * Implementations should handle OpenSearch connectivity issues gracefully with retries.
+ *
+ * <p><strong>Key Responsibilities:</strong>
+ * <ul>
+ *   <li>Verify existence of nested field mappings in indices</li>
+ *   <li>Create indices with complex nested mappings for embeddings</li>
+ *   <li>Configure KNN vector fields with appropriate dimensions and algorithms</li>
+ * </ul>
+ *
+ * @author PipeStream.ai
+ * @version 1.0
+ * @see OpenSearchSchemaServiceImpl
+ * @see VectorFieldDefinition
  */
 public interface OpenSearchSchemaService {
 
     /**
      * Checks if a specific nested field mapping exists within a given index.
      *
-     * @param indexName The name of the index to check.
-     * @param nestedFieldName The name of the nested field (e.g., "embeddings").
-     * @return A Uni that resolves to true if the mapping exists, false otherwise.
+     * <p>This method verifies both that the index exists and that it contains a
+     * nested field with the specified name. This is useful for ensuring schema
+     * compatibility before indexing documents with embeddings.
+     *
+     * <p>The operation is idempotent and safe to call multiple times.
+     *
+     * @param indexName the name of the index to check (e.g., "documents")
+     * @param nestedFieldName the name of the nested field to verify (e.g., "embeddings_384")
+     * @return a {@link Uni} that resolves to true if the nested mapping exists, false otherwise
      */
     Uni<Boolean> nestedMappingExists(String indexName, String nestedFieldName);
 
     /**
-     * Creates an index with a specific nested mapping for storing embeddings.
+     * Creates an OpenSearch index with a nested mapping for storing vector embeddings.
      *
-     * @param indexName The name of the index to create.
-     * @param nestedFieldName The name of the nested field (e.g., "embeddings").
-     * @param vectorFieldDefinition The configuration for the knn_vector field inside the nested mapping.
-     * @return A Uni that resolves to true if the creation was successful, false otherwise.
+     * <p>This method creates a new index with KNN enabled and configures a nested field
+     * structure suitable for storing embeddings with metadata. The nested structure includes:
+     * <ul>
+     *   <li><strong>vector</strong> - knn_vector field with specified dimensions and algorithm</li>
+     *   <li><strong>source_text</strong> - the original text that was embedded</li>
+     *   <li><strong>context_text</strong> - additional context for the embedding</li>
+     *   <li><strong>chunk_config_id</strong> - identifier for chunking configuration</li>
+     *   <li><strong>embedding_id</strong> - unique identifier for the embedding</li>
+     *   <li><strong>is_primary</strong> - flag indicating if this is the primary embedding</li>
+     * </ul>
+     *
+     * <p>The vector field is configured according to the provided {@link VectorFieldDefinition},
+     * which specifies dimension, distance metric (L2, cosine, inner product), and algorithm
+     * parameters (HNSW: M, ef_construction, ef_search).
+     *
+     * <p><strong>Note:</strong> If the index already exists, this operation will fail. Use
+     * {@link #nestedMappingExists(String, String)} to check before creating.
+     *
+     * @param indexName the name of the index to create (e.g., "documents")
+     * @param nestedFieldName the name of the nested field (e.g., "embeddings_384")
+     * @param vectorFieldDefinition the configuration for the knn_vector field dimensions and algorithm
+     * @return a {@link Uni} that resolves to true if creation succeeded, false otherwise
      */
     Uni<Boolean> createIndexWithNestedMapping(String indexName, String nestedFieldName, VectorFieldDefinition vectorFieldDefinition);
 

--- a/src/main/java/ai/pipestream/schemamanager/opensearch/OpenSearchSchemaServiceImpl.java
+++ b/src/main/java/ai/pipestream/schemamanager/opensearch/OpenSearchSchemaServiceImpl.java
@@ -23,12 +23,54 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Implementation of {@link OpenSearchSchemaService} for managing index schemas and mappings.
+ *
+ * <p>This service provides robust schema management with automatic retry logic for
+ * handling transient OpenSearch connectivity issues. All operations run on worker
+ * threads to avoid blocking the event loop.
+ *
+ * <p><strong>Key Features:</strong>
+ * <ul>
+ *   <li>Automatic retry with exponential backoff (250ms to 3s, up to 6 attempts)</li>
+ *   <li>Worker thread execution for blocking I/O operations</li>
+ *   <li>KNN-enabled index creation with customizable vector field configuration</li>
+ *   <li>Support for multiple distance metrics (L2, cosine similarity, inner product)</li>
+ *   <li>HNSW algorithm configuration (M, ef_construction, ef_search parameters)</li>
+ * </ul>
+ *
+ * <p><strong>Retry Strategy:</strong><br>
+ * Operations retry on {@link IOException} and {@link HttpHostConnectException},
+ * which typically indicate transient network issues or OpenSearch being temporarily unavailable.
+ * The backoff starts at 250ms and doubles up to 3 seconds, with a maximum of 6 attempts.
+ *
+ * @author PipeStream.ai
+ * @version 1.0
+ * @see OpenSearchSchemaService
+ */
 @ApplicationScoped
 public class OpenSearchSchemaServiceImpl implements OpenSearchSchemaService {
 
+    /**
+     * Synchronous OpenSearch client for index management operations.
+     * Injected via CDI.
+     */
     @Inject
     OpenSearchClient client;
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation:
+     * <ol>
+     *   <li>Checks if the index exists</li>
+     *   <li>If it exists, retrieves the index mapping</li>
+     *   <li>Searches for a property with the specified name that has nested type</li>
+     * </ol>
+     *
+     * <p>The operation runs on a worker thread and retries up to 6 times with exponential
+     * backoff on connectivity failures.
+     */
     @Override
     public Uni<Boolean> nestedMappingExists(String indexName, String nestedFieldName) {
         return Uni.createFrom().item(() -> {
@@ -51,6 +93,13 @@ public class OpenSearchSchemaServiceImpl implements OpenSearchSchemaService {
         .atMost(6);
     }
 
+    /**
+     * Checks if the mapping response contains a nested field with the specified name.
+     *
+     * @param mapping the GetMappingResponse from OpenSearch
+     * @param nestedFieldName the name of the nested field to look for
+     * @return true if a nested field with that name exists in any of the index mappings
+     */
     private boolean mappingContainsNestedField(GetMappingResponse mapping, String nestedFieldName) {
         return mapping.result().values().stream()
                 .anyMatch(indexMapping -> {
@@ -60,6 +109,38 @@ public class OpenSearchSchemaServiceImpl implements OpenSearchSchemaService {
                 });
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation creates a comprehensive nested mapping structure:
+     * <pre>
+     * {
+     *   "mappings": {
+     *     "properties": {
+     *       "&lt;nestedFieldName&gt;": {
+     *         "type": "nested",
+     *         "properties": {
+     *           "vector": { "type": "knn_vector", "dimension": N, ... },
+     *           "source_text": { "type": "text" },
+     *           "context_text": { "type": "text" },
+     *           "chunk_config_id": { "type": "keyword" },
+     *           "embedding_id": { "type": "keyword" },
+     *           "is_primary": { "type": "boolean" }
+     *         }
+     *       }
+     *     }
+     *   },
+     *   "settings": {
+     *     "index": {
+     *       "knn": true
+     *     }
+     *   }
+     * }
+     * </pre>
+     *
+     * <p>The operation runs on a worker thread and retries up to 6 times with exponential
+     * backoff on connectivity failures.
+     */
     @Override
     public Uni<Boolean> createIndexWithNestedMapping(String indexName, String nestedFieldName, VectorFieldDefinition vectorFieldDefinition) {
         return Uni.createFrom().item(() -> {
@@ -100,6 +181,20 @@ public class OpenSearchSchemaServiceImpl implements OpenSearchSchemaService {
         .atMost(6);
     }
     
+    /**
+     * Creates a KNN vector property configuration from a vector field definition.
+     *
+     * <p>This method configures the knn_vector field with:
+     * <ul>
+     *   <li>Vector dimension</li>
+     *   <li>Distance metric (space type: L2, cosine, inner product)</li>
+     *   <li>Indexing engine (e.g., nmslib, faiss, lucene)</li>
+     *   <li>HNSW algorithm parameters (M, ef_construction, ef_search)</li>
+     * </ul>
+     *
+     * @param vectorDef the vector field definition from the protobuf request
+     * @return a configured KnnVectorProperty for OpenSearch mapping
+     */
     private KnnVectorProperty createKnnVectorProperty(VectorFieldDefinition vectorDef) {
         return KnnVectorProperty.of(knn -> {
             knn.dimension(vectorDef.getDimension());
@@ -137,6 +232,20 @@ public class OpenSearchSchemaServiceImpl implements OpenSearchSchemaService {
         });
     }
     
+    /**
+     * Maps protobuf space type enum to OpenSearch space type string.
+     *
+     * <p>Supported mappings:
+     * <ul>
+     *   <li>L2 → "l2" (Euclidean distance)</li>
+     *   <li>COSINESIMIL → "cosinesimil" (Cosine similarity)</li>
+     *   <li>INNERPRODUCT → "innerproduct" (Dot product)</li>
+     *   <li>UNRECOGNIZED → "cosinesimil" (default fallback)</li>
+     * </ul>
+     *
+     * @param spaceType the protobuf space type enum
+     * @return the OpenSearch space type string
+     */
     private String mapSpaceType(KnnMethodDefinition.SpaceType spaceType) {
         return switch (spaceType) {
             case L2 -> "l2";
@@ -146,6 +255,16 @@ public class OpenSearchSchemaServiceImpl implements OpenSearchSchemaService {
         };
     }
     
+    /**
+     * Determines the KNN algorithm method name based on space type.
+     *
+     * <p>Currently, all space types use the HNSW (Hierarchical Navigable Small World)
+     * algorithm, which provides a good balance of speed and accuracy for approximate
+     * nearest neighbor search.
+     *
+     * @param spaceType the protobuf space type enum (currently unused)
+     * @return "hnsw" for all space types
+     */
     private String getMethodName(KnnMethodDefinition.SpaceType spaceType) {
         return switch (spaceType) {
             case L2 -> "hnsw";
@@ -155,6 +274,23 @@ public class OpenSearchSchemaServiceImpl implements OpenSearchSchemaService {
         };
     }
 
+    /**
+     * Determines if an exception is retryable (transient network issue).
+     *
+     * <p>This method identifies exceptions that are likely to be resolved by retrying,
+     * specifically {@link IOException} and {@link HttpHostConnectException}, which
+     * typically indicate:
+     * <ul>
+     *   <li>OpenSearch service temporarily unavailable</li>
+     *   <li>Network connectivity issues</li>
+     *   <li>Connection timeouts</li>
+     * </ul>
+     *
+     * <p>The method unwraps {@link RuntimeException} to check the root cause.
+     *
+     * @param throwable the exception to check
+     * @return true if the exception is retryable, false otherwise
+     */
     private boolean isRetryable(Throwable throwable) {
         Throwable root = throwable;
         if (throwable instanceof RuntimeException && throwable.getCause() != null) {


### PR DESCRIPTION
Added detailed Javadoc documentation to all 8 Java source files in the opensearch-manager project, providing comprehensive API documentation for:

- Class-level descriptions with architectural context
- Method-level documentation with @param and @return tags
- Field documentation for injected dependencies and configuration
- Usage examples and implementation notes where appropriate
- Cross-references using @see tags

Key improvements:
- OpenSearchManagerService: Documented gRPC endpoints and Strategy 1 for embeddings
- OpenSearchIndexingService: Comprehensive docs for all entity indexing operations
- OpenSearchSchemaService(Impl): Detailed KNN vector field configuration docs
- RepositoryUpdateConsumer: Kafka topic consumption and error handling docs
- OpenSearchClientProducer: CDI producer configuration and SSL/auth setup docs
- IndexInitializer: Startup initialization and retry strategy documentation
- IndexConstants: Type-safe constant enums with usage documentation

All documentation follows standard Javadoc conventions with proper HTML formatting, parameter descriptions, and return value documentation.

Total changes: 1,180 lines added across 8 files