### PR TITLE
feat: index drive_type, graph_id, cluster_id for telemetry

### DIFF
--- a/opensearch-manager/build.gradle
+++ b/opensearch-manager/build.gradle
@@ -29,10 +29,10 @@ pipestreamProtos {
     def localProtos = file("${rootDir}/../../pipestream-protos")
     if (localProtos.directory && new File(localProtos, ".git").exists()) {
         gitRepo = "file://${localProtos.absolutePath}"
-        gitRef = "main"
+        gitRef = "feature/dual-drive-s3-layout"
     } else {
         gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
-        gitRef = "main"
+        gitRef = "feature/dual-drive-s3-layout"
     }
 
     modules {

--- a/opensearch-manager/build.gradle
+++ b/opensearch-manager/build.gradle
@@ -29,10 +29,10 @@ pipestreamProtos {
     def localProtos = file("${rootDir}/../../pipestream-protos")
     if (localProtos.directory && new File(localProtos, ".git").exists()) {
         gitRepo = "file://${localProtos.absolutePath}"
-        gitRef = "feature/dual-drive-s3-layout"
+        gitRef = "main"
     } else {
         gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
-        gitRef = "feature/dual-drive-s3-layout"
+        gitRef = "main"
     }
 
     modules {

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchIndexingService.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchIndexingService.java
@@ -391,6 +391,15 @@ public class OpenSearchIndexingService {
         if (notification.hasRetentionIntentDays()) {
             document.put("retention_intent_days", notification.getRetentionIntentDays());
         }
+        if (!notification.getDriveType().isEmpty()) {
+            document.put("drive_type", notification.getDriveType());
+        }
+        if (!notification.getGraphId().isEmpty()) {
+            document.put("graph_id", notification.getGraphId());
+        }
+        if (!notification.getClusterId().isEmpty()) {
+            document.put("cluster_id", notification.getClusterId());
+        }
         document.put(CommonFields.CREATED_AT.getFieldName(), notification.getCreatedAt().getSeconds() * 1000);
         document.put(CommonFields.UPDATED_AT.getFieldName(), notification.getUpdatedAt().getSeconds() * 1000);
         document.put(CommonFields.INDEXED_AT.getFieldName(), System.currentTimeMillis());


### PR DESCRIPTION
## Summary
- Index new `drive_type`, `graph_id`, `cluster_id` fields from PipeDocUpdateNotification in the pipedocs OpenSearch index

## Test plan
- [x] Compiles clean against updated protos