### PR TITLE
fix: bulk indexing stall + SemanticGranularity → GranularityLevel migration

### DIFF
--- a/opensearch-manager/build.gradle
+++ b/opensearch-manager/build.gradle
@@ -27,12 +27,15 @@ def pipestreamBomVersion = findProperty('pipestreamBomVersion')
 pipestreamProtos {
     sourceMode = 'git-proto-workspace'
     def localProtos = file("${rootDir}/../../pipestream-protos")
+    // Temporarily pinned to proto/quality-and-classification until the
+    // GranularityLevel migration (PR #31) merges to main and is republished.
+    // Revert both gitRef lines to "main" after the cross-repo rollout completes.
     if (localProtos.directory && new File(localProtos, ".git").exists()) {
         gitRepo = "file://${localProtos.absolutePath}"
-        gitRef = "main"
+        gitRef = "proto/quality-and-classification"
     } else {
         gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
-        gitRef = "main"
+        gitRef = "proto/quality-and-classification"
     }
 
     modules {

--- a/opensearch-manager/build.gradle
+++ b/opensearch-manager/build.gradle
@@ -26,17 +26,8 @@ def pipestreamBomVersion = findProperty('pipestreamBomVersion')
 // Proto toolchain configuration - uses git-proto-workspace mode for cross-module imports
 pipestreamProtos {
     sourceMode = 'git-proto-workspace'
-    def localProtos = file("${rootDir}/../../pipestream-protos")
-    // Temporarily pinned to proto/quality-and-classification until the
-    // GranularityLevel migration (PR #31) merges to main and is republished.
-    // Revert both gitRef lines to "main" after the cross-repo rollout completes.
-    if (localProtos.directory && new File(localProtos, ".git").exists()) {
-        gitRepo = "file://${localProtos.absolutePath}"
-        gitRef = "proto/quality-and-classification"
-    } else {
-        gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
-        gitRef = "proto/quality-and-classification"
-    }
+    gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
+    gitRef = "main"
 
     modules {
         // Register modules by name only - workspace mode handles cross-module imports

--- a/opensearch-manager/docs/ai-slop/CRAWL_EVENT_OBSERVABILITY.md
+++ b/opensearch-manager/docs/ai-slop/CRAWL_EVENT_OBSERVABILITY.md
@@ -1,0 +1,212 @@
+# Crawl Event Observability Guide
+
+This guide shows how to inspect crawl progress and timing directly from `pipeline-events-*`.
+
+## Which URL to query
+
+OpenSearch **HTTP REST** is almost always on **port 9200**, e.g. `https://<host>:9200/...`, matching `opensearch.hosts` (`OPENSEARCH_HOST` + `OPENSEARCH_PORT`, default port **9200**) and `opensearch.protocol`. The site root on **port 443** is often **OpenSearch Dashboards** or another UI; `curl https://<host>/` is **not** the same as the indexing API. Use the same base URL your `opensearch-manager` uses.
+
+## What is stored per event
+
+Each event document includes:
+
+- Core routing fields: `document_id`, `stream_id`, `graph_id`, `node_id`, `module_id`, `status`, `duration_ms`
+- Error fields when present: `error_code`, `error_message`
+- Log metadata: `log_entry_count`, `log_entries_stored_count`, `log_entries_dropped_count`, `log_entries_total_chars`, `log_entries_truncated`
+- Capped log payload: `log_entries[]` (timestamp, level, source, message, optional module/engine origin)
+- Semantic telemetry when emitted: `semantic_manager_telemetry.*`
+
+## Log entry caps
+
+To keep indexing safe and predictable:
+
+- Max stored log entries per event: `40`
+- Max total stored log message chars per event: `12000`
+- Max chars per individual log message: `1000`
+
+When truncation happens:
+
+- `log_entries_truncated: true`
+- `log_entries_dropped_count > 0` when entries were omitted
+- Individual entries may include `message_truncated: true`
+
+## 1) Confirm events are arriving for a crawl
+
+Use either `stream_id` or `graph_id` as your primary filter.
+
+```json
+GET /pipeline-events-*/_search
+{
+  "size": 20,
+  "sort": [{"event_timestamp": "desc"}],
+  "_source": [
+    "event_timestamp",
+    "document_id",
+    "stream_id",
+    "graph_id",
+    "node_id",
+    "module_id",
+    "status",
+    "duration_ms",
+    "log_entry_count"
+  ],
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"stream_id.keyword": "<stream-id>"}}
+      ]
+    }
+  }
+}
+```
+
+## 2) Measure bottlenecks by node
+
+```json
+GET /pipeline-events-*/_search
+{
+  "size": 0,
+  "query": {
+    "term": {"stream_id.keyword": "<stream-id>"}
+  },
+  "aggs": {
+    "by_node": {
+      "terms": {"field": "node_id.keyword", "size": 50},
+      "aggs": {
+        "count": {"value_count": {"field": "document_id.keyword"}},
+        "avg_ms": {"avg": {"field": "duration_ms"}},
+        "p95_ms": {"percentiles": {"field": "duration_ms", "percents": [50, 95, 99]}},
+        "max_ms": {"max": {"field": "duration_ms"}}
+      }
+    }
+  }
+}
+```
+
+## 3) Track semantic-manager telemetry
+
+```json
+GET /pipeline-events-*/_search
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"stream_id.keyword": "<stream-id>"}},
+        {"term": {"module_id.keyword": "semantic-manager"}}
+      ]
+    }
+  },
+  "aggs": {
+    "outcomes": {
+      "terms": {"field": "semantic_manager_telemetry.outcome.keyword"},
+      "aggs": {
+        "avg_duration_ms": {"avg": {"field": "semantic_manager_telemetry.duration_ms"}},
+        "p95_duration_ms": {
+          "percentiles": {
+            "field": "semantic_manager_telemetry.duration_ms",
+            "percents": [50, 95, 99]
+          }
+        },
+        "avg_chunk_count": {"avg": {"field": "semantic_manager_telemetry.chunk_count"}},
+        "avg_failed_embeddings": {"avg": {"field": "semantic_manager_telemetry.failed_embeddings"}}
+      }
+    }
+  }
+}
+```
+
+## 4) Inspect slow documents with full context
+
+```json
+GET /pipeline-events-*/_search
+{
+  "size": 25,
+  "sort": [{"duration_ms": "desc"}],
+  "_source": [
+    "document_id",
+    "stream_id",
+    "node_id",
+    "module_id",
+    "status",
+    "duration_ms",
+    "error_message",
+    "semantic_manager_telemetry",
+    "log_entries"
+  ],
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"stream_id.keyword": "<stream-id>"}}
+      ]
+    }
+  }
+}
+```
+
+## 5) Check whether logs are being capped
+
+```json
+GET /pipeline-events-*/_search
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"stream_id.keyword": "<stream-id>"}},
+        {"term": {"log_entries_truncated": true}}
+      ]
+    }
+  },
+  "aggs": {
+    "avg_dropped": {"avg": {"field": "log_entries_dropped_count"}},
+    "max_dropped": {"max": {"field": "log_entries_dropped_count"}}
+  }
+}
+```
+
+## 6) Pull phase timing lines from stored logs
+
+Semantic-manager phase timing is emitted as log lines (`Phase 0 timing`, `Phase 1 timing`, `Phase 2 timing`, `Semantic orchestration complete`).
+
+```json
+GET /pipeline-events-*/_search
+{
+  "size": 50,
+  "sort": [{"event_timestamp": "desc"}],
+  "_source": [
+    "document_id",
+    "node_id",
+    "module_id",
+    "log_entries.message"
+  ],
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"stream_id.keyword": "<stream-id>"}}
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {"wildcard": {"log_entries.message.keyword": "*Phase 0 timing*"}},
+              {"wildcard": {"log_entries.message.keyword": "*Phase 1 timing*"}},
+              {"wildcard": {"log_entries.message.keyword": "*Phase 2 timing*"}},
+              {"wildcard": {"log_entries.message.keyword": "*Semantic orchestration complete*"}}
+            ],
+            "minimum_should_match": 1
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Practical workflow
+
+1. Filter by `stream_id` for one crawl run.
+2. Run node-level aggregation to find highest `p95`/`max` duration.
+3. Inspect top slow docs for those nodes.
+4. Check `semantic_manager_telemetry` and `log_entries` on slow docs.
+5. Confirm whether log truncation is hiding detail (`log_entries_truncated`).

--- a/opensearch-manager/docs/superpowers/plans/2026-04-07-bulk-indexing-queues.md
+++ b/opensearch-manager/docs/superpowers/plans/2026-04-07-bulk-indexing-queues.md
@@ -1,0 +1,1428 @@
+# Bulk Indexing Queue System — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace single-document OpenSearch indexing with N concurrent draining queues that bulk-flush to OpenSearch, achieving 10-100x throughput improvement.
+
+**Architecture:** A `BulkQueueSet` manages N concurrent `BulkIndexingQueue` instances (default 4, range 2-10). Every indexing operation — entity telemetry, nested documents, chunk documents — submits items to the queue set via round-robin. Each queue independently drains on a timer (2s) or capacity threshold (200 items) and sends a single OpenSearch bulk request containing mixed indices. A volatile reference swap enables runtime resize without restart. gRPC admin endpoints expose `GetBulkConfig` / `UpdateBulkConfig` for live tuning.
+
+**Tech Stack:** Java 21, Quarkus 3.34, OpenSearch Java Client (`OpenSearchAsyncClient`), Mutiny (Uni/Multi), `java.util.concurrent` (LinkedBlockingQueue, ScheduledExecutorService, CompletableFuture)
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexItem.java` | Immutable record: indexName, docId, document map, optional routing, optional CompletableFuture for response |
+| `src/main/java/ai/pipestream/schemamanager/bulk/BulkItemResult.java` | Immutable record: success boolean, failureDetail string |
+| `src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingQueue.java` | Single draining queue: LinkedBlockingQueue + ScheduledExecutorService flush timer, builds & sends BulkRequest |
+| `src/main/java/ai/pipestream/schemamanager/bulk/BulkQueueSet.java` | ApplicationScoped bean: N concurrent queues, round-robin submit, volatile swap resize, lifecycle management |
+| `src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingConfig.java` | Quarkus @ConfigMapping for static defaults (queue-count, capacity, flush-interval-ms) |
+| `src/test/java/ai/pipestream/schemamanager/bulk/BulkQueueSetTest.java` | Unit tests for queue set: batching, flush triggers, round-robin, resize, error propagation |
+| `src/test/java/ai/pipestream/schemamanager/bulk/BulkIndexingQueueTest.java` | Unit tests for single queue: capacity flush, timer flush, mixed indices, CompletableFuture completion |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `opensearch/proto/.../opensearch_manager.proto` | Add `GetBulkConfig`/`UpdateBulkConfig` RPCs + messages |
+| `OpenSearchIndexingService.java` | Replace entity emitter (`MultiEmitter` + `group().intoLists()`) with `BulkQueueSet.submitFireAndForget()`; remove `entityEmitter` field, `onStartup`/`onShutdown` entity pipeline, `processEntityBatch`, `indexEntityDirect` |
+| `OpenSearchManagerService.java` | Add gRPC handlers for `GetBulkConfig` and `UpdateBulkConfig` |
+| `NestedIndexingStrategy.java` | Replace `indexDocumentToOpenSearchViaRest()` with `bulkQueueSet.submit()` returning `Uni<BulkItemResult>` |
+| `ChunkCombinedIndexingStrategy.java` | Replace `bulkIndexChunkDocs()` manual BulkRequest with per-chunk `bulkQueueSet.submit()` calls; replace `indexBaseDocument()` direct index call with `bulkQueueSet.submit()` |
+| `application.properties` | Add `bulk-indexing.queue-count`, `bulk-indexing.capacity`, `bulk-indexing.flush-interval-ms` defaults |
+
+---
+
+## Task 1: Proto — BulkConfig Messages and RPCs
+
+**Files:**
+- Modify: `/work/core-services/pipestream-protos/opensearch/proto/ai/pipestream/opensearch/v1/opensearch_manager.proto`
+
+- [ ] **Step 1: Add BulkConfig messages and RPCs to proto**
+
+Append below the existing `SearchDocumentUploadsResponse` message (after line 412) and add RPCs to the service block:
+
+```protobuf
+// === Bulk Indexing Configuration ===
+
+// Runtime configuration for the bulk indexing queue system.
+message BulkIndexingConfig {
+  // Number of concurrent draining queues (range: 2-10, default: 4)
+  int32 queue_count = 1;
+  // Maximum items per queue before forced flush (default: 200)
+  int32 queue_capacity = 2;
+  // Milliseconds between periodic flush sweeps (default: 2000)
+  int32 flush_interval_ms = 3;
+}
+
+// Request to update the bulk indexing queue configuration at runtime.
+message UpdateBulkConfigRequest {
+  BulkIndexingConfig config = 1;
+}
+
+// Response from bulk config update with the active configuration.
+message UpdateBulkConfigResponse {
+  bool success = 1;
+  BulkIndexingConfig active_config = 2;
+  string message = 3;
+}
+
+// Request to retrieve the current bulk indexing configuration.
+message GetBulkConfigRequest {}
+
+// Response containing the current bulk indexing configuration.
+message GetBulkConfigResponse {
+  BulkIndexingConfig config = 1;
+}
+```
+
+Add to the `OpenSearchManagerService` service block (after `SearchDocumentUploads` RPC):
+
+```protobuf
+  // Retrieves the current bulk indexing queue configuration.
+  rpc GetBulkConfig(GetBulkConfigRequest) returns (GetBulkConfigResponse);
+  // Updates the bulk indexing queue configuration at runtime (queue count, capacity, flush interval).
+  rpc UpdateBulkConfig(UpdateBulkConfigRequest) returns (UpdateBulkConfigResponse);
+```
+
+- [ ] **Step 2: Build protos**
+
+Run: `cd /work/core-services/pipestream-protos && ./gradlew clean build -x test`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Update opensearch-manager's proto gitRef to pick up new messages**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava` to verify the new messages are visible.
+Expected: Compilation succeeds, `BulkIndexingConfig`, `UpdateBulkConfigRequest`, etc. classes are generated.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/core-services/pipestream-protos
+git add opensearch/proto/ai/pipestream/opensearch/v1/opensearch_manager.proto
+git commit -m "proto: add BulkIndexingConfig messages and GetBulkConfig/UpdateBulkConfig RPCs"
+```
+
+---
+
+## Task 2: BulkIndexItem and BulkItemResult Records
+
+**Files:**
+- Create: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexItem.java`
+- Create: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkItemResult.java`
+
+- [ ] **Step 1: Create BulkItemResult record**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+/**
+ * Result of a single item within a bulk indexing flush.
+ */
+public record BulkItemResult(boolean success, String failureDetail) {
+    public static BulkItemResult ok() {
+        return new BulkItemResult(true, null);
+    }
+
+    public static BulkItemResult failed(String detail) {
+        return new BulkItemResult(false, detail);
+    }
+}
+```
+
+- [ ] **Step 2: Create BulkIndexItem record**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A single indexing operation to be batched into an OpenSearch bulk request.
+ *
+ * @param indexName    target OpenSearch index
+ * @param docId        document ID for upsert
+ * @param document     document body as a Map (ready for OpenSearch client)
+ * @param routing      optional routing value (null if not needed)
+ * @param resultFuture optional future completed when the bulk response arrives;
+ *                     null for fire-and-forget submissions (entity telemetry)
+ */
+public record BulkIndexItem(
+    String indexName,
+    String docId,
+    Map<String, Object> document,
+    String routing,
+    CompletableFuture<BulkItemResult> resultFuture
+) {
+    /** Fire-and-forget constructor (no routing, no future). */
+    public static BulkIndexItem fireAndForget(String indexName, String docId, Map<String, Object> document) {
+        return new BulkIndexItem(indexName, docId, document, null, null);
+    }
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/
+git commit -m "feat: add BulkIndexItem and BulkItemResult records for bulk queue system"
+```
+
+---
+
+## Task 3: BulkIndexingConfig — Quarkus ConfigMapping
+
+**Files:**
+- Create: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingConfig.java`
+- Modify: `opensearch-manager/src/main/resources/application.properties`
+
+- [ ] **Step 1: Create the config mapping interface**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Static defaults for the bulk indexing queue system.
+ * Runtime tuning via gRPC UpdateBulkConfig overrides these at the BulkQueueSet level.
+ */
+@ConfigMapping(prefix = "bulk-indexing")
+public interface BulkIndexingConfig {
+
+    /** Number of concurrent draining queues. Range: 2-10. */
+    @WithDefault("4")
+    int queueCount();
+
+    /** Maximum items per queue before forced flush. */
+    @WithDefault("200")
+    int capacity();
+
+    /** Milliseconds between periodic flush sweeps. */
+    @WithDefault("2000")
+    int flushIntervalMs();
+}
+```
+
+- [ ] **Step 2: Add defaults to application.properties**
+
+Append to end of `application.properties`:
+
+```properties
+
+# ======================================================================================================================
+# Bulk Indexing Queue Configuration
+# ======================================================================================================================
+# Number of concurrent draining queues (range 2-10)
+bulk-indexing.queue-count=4
+# Maximum items per queue before forced flush
+bulk-indexing.capacity=200
+# Milliseconds between periodic flush sweeps
+bulk-indexing.flush-interval-ms=2000
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingConfig.java
+git add opensearch-manager/src/main/resources/application.properties
+git commit -m "feat: add BulkIndexingConfig with static defaults for bulk queue system"
+```
+
+---
+
+## Task 4: BulkIndexingQueue — Single Draining Queue
+
+**Files:**
+- Create: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingQueue.java`
+- Create: `opensearch-manager/src/test/java/ai/pipestream/schemamanager/bulk/BulkIndexingQueueTest.java`
+
+- [ ] **Step 1: Write the failing test for BulkIndexingQueue**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BulkIndexingQueueTest {
+
+    private BulkIndexingQueue queue;
+
+    @AfterEach
+    void tearDown() {
+        if (queue != null) {
+            queue.shutdown();
+        }
+    }
+
+    @Test
+    void capacityFlush_triggersWhenQueueReachesCapacity() throws Exception {
+        int capacity = 5;
+        List<List<BulkIndexItem>> flushedBatches = Collections.synchronizedList(new ArrayList<>());
+        Consumer<List<BulkIndexItem>> flushHandler = batch -> flushedBatches.add(new ArrayList<>(batch));
+
+        queue = new BulkIndexingQueue(0, capacity, 60_000, flushHandler);
+        queue.start();
+
+        // Submit exactly capacity items
+        List<CompletableFuture<BulkItemResult>> futures = new ArrayList<>();
+        for (int i = 0; i < capacity; i++) {
+            CompletableFuture<BulkItemResult> f = new CompletableFuture<>();
+            queue.submit(new BulkIndexItem("test-index", "doc-" + i, Map.of("field", "value-" + i), null, f));
+            futures.add(f);
+        }
+
+        // Capacity threshold should trigger flush quickly
+        Thread.sleep(200);
+
+        assertThat(flushedBatches)
+                .as("Should have flushed exactly one batch when capacity reached")
+                .hasSize(1);
+        assertThat(flushedBatches.get(0))
+                .as("Flushed batch should contain all %d items", capacity)
+                .hasSize(capacity);
+    }
+
+    @Test
+    void timerFlush_triggersAtInterval() throws Exception {
+        int flushIntervalMs = 300;
+        List<List<BulkIndexItem>> flushedBatches = Collections.synchronizedList(new ArrayList<>());
+        Consumer<List<BulkIndexItem>> flushHandler = batch -> flushedBatches.add(new ArrayList<>(batch));
+
+        queue = new BulkIndexingQueue(0, 1000, flushIntervalMs, flushHandler);
+        queue.start();
+
+        // Submit fewer items than capacity
+        queue.submit(new BulkIndexItem("test-index", "doc-1", Map.of("a", "b"), null, null));
+        queue.submit(new BulkIndexItem("test-index", "doc-2", Map.of("a", "c"), null, null));
+
+        // Wait for timer to fire
+        Thread.sleep(flushIntervalMs + 200);
+
+        assertThat(flushedBatches)
+                .as("Timer should have flushed the partial batch")
+                .hasSizeGreaterThanOrEqualTo(1);
+        assertThat(flushedBatches.get(0))
+                .as("Flushed batch should contain the 2 submitted items")
+                .hasSize(2);
+    }
+
+    @Test
+    void mixedIndices_allIncludedInSingleFlush() throws Exception {
+        List<List<BulkIndexItem>> flushedBatches = Collections.synchronizedList(new ArrayList<>());
+        Consumer<List<BulkIndexItem>> flushHandler = batch -> flushedBatches.add(new ArrayList<>(batch));
+
+        queue = new BulkIndexingQueue(0, 3, 60_000, flushHandler);
+        queue.start();
+
+        queue.submit(new BulkIndexItem("index-a", "doc-1", Map.of("x", "1"), null, null));
+        queue.submit(new BulkIndexItem("index-b", "doc-2", Map.of("x", "2"), null, null));
+        queue.submit(new BulkIndexItem("index-c", "doc-3", Map.of("x", "3"), null, null));
+
+        Thread.sleep(200);
+
+        assertThat(flushedBatches)
+                .as("Capacity flush should fire with mixed indices")
+                .hasSize(1);
+
+        List<String> indices = flushedBatches.get(0).stream()
+                .map(BulkIndexItem::indexName)
+                .toList();
+        assertThat(indices)
+                .as("Single bulk flush should contain items from all three indices")
+                .containsExactly("index-a", "index-b", "index-c");
+    }
+
+    @Test
+    void fireAndForget_noFutureNoException() throws Exception {
+        List<List<BulkIndexItem>> flushedBatches = Collections.synchronizedList(new ArrayList<>());
+        Consumer<List<BulkIndexItem>> flushHandler = batch -> flushedBatches.add(new ArrayList<>(batch));
+
+        queue = new BulkIndexingQueue(0, 1, 60_000, flushHandler);
+        queue.start();
+
+        // Fire-and-forget: no future
+        queue.submit(BulkIndexItem.fireAndForget("test-index", "doc-1", Map.of("a", "b")));
+
+        Thread.sleep(200);
+
+        assertThat(flushedBatches)
+                .as("Fire-and-forget item should still be flushed")
+                .hasSize(1);
+    }
+
+    @Test
+    void drainRemaining_returnsUnflushedItems() throws Exception {
+        List<List<BulkIndexItem>> flushedBatches = Collections.synchronizedList(new ArrayList<>());
+        Consumer<List<BulkIndexItem>> flushHandler = batch -> flushedBatches.add(new ArrayList<>(batch));
+
+        // Large capacity, long timer — nothing flushes automatically
+        queue = new BulkIndexingQueue(0, 1000, 60_000, flushHandler);
+        queue.start();
+
+        queue.submit(BulkIndexItem.fireAndForget("idx", "d1", Map.of()));
+        queue.submit(BulkIndexItem.fireAndForget("idx", "d2", Map.of()));
+
+        List<BulkIndexItem> drained = queue.drainRemaining();
+        assertThat(drained)
+                .as("drainRemaining should return all unflushed items")
+                .hasSize(2);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --tests '*BulkIndexingQueueTest*' --no-daemon 2>&1 | tail -20`
+Expected: FAIL — `BulkIndexingQueue` class does not exist
+
+- [ ] **Step 3: Implement BulkIndexingQueue**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * A single draining queue that accumulates BulkIndexItems and periodically flushes them.
+ * Flush triggers: capacity threshold OR timer interval (whichever fires first).
+ *
+ * <p>The flushHandler callback receives the drained batch and is responsible for
+ * building the OpenSearch BulkRequest and completing the item futures.</p>
+ */
+public class BulkIndexingQueue {
+
+    private static final Logger LOG = Logger.getLogger(BulkIndexingQueue.class);
+
+    private final int queueId;
+    private final int capacity;
+    private final int flushIntervalMs;
+    private final Consumer<List<BulkIndexItem>> flushHandler;
+    private final LinkedBlockingQueue<BulkIndexItem> queue;
+    private volatile ScheduledFuture<?> timerHandle;
+    private volatile boolean running;
+
+    public BulkIndexingQueue(int queueId, int capacity, int flushIntervalMs,
+                             Consumer<List<BulkIndexItem>> flushHandler) {
+        this.queueId = queueId;
+        this.capacity = capacity;
+        this.flushIntervalMs = flushIntervalMs;
+        this.flushHandler = flushHandler;
+        this.queue = new LinkedBlockingQueue<>();
+    }
+
+    /**
+     * Starts the periodic flush timer on the given scheduler.
+     */
+    public void start(ScheduledExecutorService scheduler) {
+        this.running = true;
+        this.timerHandle = scheduler.scheduleAtFixedRate(
+                this::timerFlush, flushIntervalMs, flushIntervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Starts with an internal single-thread scheduler (for tests).
+     */
+    public void start() {
+        start(java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "bulk-queue-" + queueId);
+            t.setDaemon(true);
+            return t;
+        }));
+    }
+
+    /**
+     * Submits an item to this queue. If capacity is reached, triggers an immediate flush.
+     */
+    public void submit(BulkIndexItem item) {
+        queue.offer(item);
+        if (queue.size() >= capacity) {
+            flush();
+        }
+    }
+
+    /**
+     * Drains all items from the queue and invokes the flush handler.
+     * Safe to call from any thread — LinkedBlockingQueue.drainTo is thread-safe.
+     */
+    public void flush() {
+        List<BulkIndexItem> batch = new ArrayList<>(Math.min(queue.size(), capacity));
+        queue.drainTo(batch);
+        if (!batch.isEmpty()) {
+            LOG.debugf("Queue %d flushing %d items", queueId, batch.size());
+            try {
+                flushHandler.accept(batch);
+            } catch (Exception e) {
+                LOG.errorf(e, "Queue %d flush handler failed for batch of %d items", queueId, batch.size());
+                // Complete futures with error
+                for (BulkIndexItem item : batch) {
+                    if (item.resultFuture() != null) {
+                        item.resultFuture().complete(BulkItemResult.failed("Flush handler error: " + e.getMessage()));
+                    }
+                }
+            }
+        }
+    }
+
+    private void timerFlush() {
+        if (running && !queue.isEmpty()) {
+            flush();
+        }
+    }
+
+    /**
+     * Drains remaining items without flushing them. Used during resize to move items to new queues.
+     */
+    public List<BulkIndexItem> drainRemaining() {
+        List<BulkIndexItem> remaining = new ArrayList<>();
+        queue.drainTo(remaining);
+        return remaining;
+    }
+
+    /**
+     * Stops the timer and marks this queue as not running.
+     * Does NOT drain remaining items — call drainRemaining() first if needed.
+     */
+    public void shutdown() {
+        this.running = false;
+        if (timerHandle != null) {
+            timerHandle.cancel(false);
+        }
+    }
+
+    public int pendingCount() {
+        return queue.size();
+    }
+
+    public int queueId() {
+        return queueId;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --tests '*BulkIndexingQueueTest*' --no-daemon 2>&1 | tail -20`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingQueue.java
+git add opensearch-manager/src/test/java/ai/pipestream/schemamanager/bulk/BulkIndexingQueueTest.java
+git commit -m "feat: add BulkIndexingQueue — single draining queue with capacity+timer flush"
+```
+
+---
+
+## Task 5: BulkQueueSet — N Concurrent Queues with Round-Robin and Resize
+
+**Files:**
+- Create: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkQueueSet.java`
+- Create: `opensearch-manager/src/test/java/ai/pipestream/schemamanager/bulk/BulkQueueSetTest.java`
+
+- [ ] **Step 1: Write the failing test for BulkQueueSet**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class BulkQueueSetTest {
+
+    private BulkQueueSet queueSet;
+
+    @AfterEach
+    void tearDown() {
+        if (queueSet != null) {
+            queueSet.shutdown();
+        }
+    }
+
+    @Test
+    void roundRobin_distributesAcrossQueues() throws Exception {
+        // Track which queues receive items via flush batches
+        List<List<BulkIndexItem>> allBatches = Collections.synchronizedList(new ArrayList<>());
+
+        queueSet = new BulkQueueSet(4, 1, 60_000, batch -> allBatches.add(new ArrayList<>(batch)));
+        queueSet.start();
+
+        // Submit 4 items — each should go to a different queue and flush immediately (capacity=1)
+        for (int i = 0; i < 4; i++) {
+            queueSet.submit(BulkIndexItem.fireAndForget("idx", "doc-" + i, Map.of()));
+        }
+
+        Thread.sleep(300);
+
+        assertThat(allBatches)
+                .as("4 items with capacity=1 across 4 queues should produce 4 batches")
+                .hasSize(4);
+        for (List<BulkIndexItem> batch : allBatches) {
+            assertThat(batch)
+                    .as("Each batch should contain exactly 1 item")
+                    .hasSize(1);
+        }
+    }
+
+    @Test
+    void submit_withFuture_completesOnFlush() throws Exception {
+        AtomicInteger flushCount = new AtomicInteger();
+
+        queueSet = new BulkQueueSet(1, 2, 60_000, batch -> {
+            flushCount.incrementAndGet();
+            // Simulate successful flush by completing all futures
+            for (BulkIndexItem item : batch) {
+                if (item.resultFuture() != null) {
+                    item.resultFuture().complete(BulkItemResult.ok());
+                }
+            }
+        });
+        queueSet.start();
+
+        CompletableFuture<BulkItemResult> f1 = new CompletableFuture<>();
+        CompletableFuture<BulkItemResult> f2 = new CompletableFuture<>();
+
+        queueSet.submit(new BulkIndexItem("idx", "d1", Map.of(), null, f1));
+        queueSet.submit(new BulkIndexItem("idx", "d2", Map.of(), null, f2));
+
+        // Capacity=2, so flush should trigger
+        BulkItemResult r1 = f1.get(2, TimeUnit.SECONDS);
+        BulkItemResult r2 = f2.get(2, TimeUnit.SECONDS);
+
+        assertThat(r1.success()).as("First item should succeed").isTrue();
+        assertThat(r2.success()).as("Second item should succeed").isTrue();
+        assertThat(flushCount.get()).as("Should have flushed once").isEqualTo(1);
+    }
+
+    @Test
+    void resize_drainOldQueueItemsToNewQueues() throws Exception {
+        List<List<BulkIndexItem>> allBatches = Collections.synchronizedList(new ArrayList<>());
+
+        // Start with 2 queues, large capacity so nothing flushes automatically
+        queueSet = new BulkQueueSet(2, 1000, 60_000, batch -> allBatches.add(new ArrayList<>(batch)));
+        queueSet.start();
+
+        // Submit items
+        for (int i = 0; i < 6; i++) {
+            queueSet.submit(BulkIndexItem.fireAndForget("idx", "doc-" + i, Map.of()));
+        }
+
+        // Resize to 4 queues
+        queueSet.resize(4, 1000, 60_000);
+
+        // Force flush all queues
+        queueSet.flushAll();
+        Thread.sleep(200);
+
+        // All 6 items should have been drained from old queues and flushed from new queues
+        int totalFlushed = allBatches.stream().mapToInt(List::size).sum();
+        assertThat(totalFlushed)
+                .as("All 6 items should eventually be flushed after resize")
+                .isEqualTo(6);
+    }
+
+    @Test
+    void getActiveConfig_reflectsCurrentState() throws Exception {
+        queueSet = new BulkQueueSet(3, 150, 1500, batch -> {});
+        queueSet.start();
+
+        assertThat(queueSet.getQueueCount()).as("Queue count").isEqualTo(3);
+        assertThat(queueSet.getCapacity()).as("Capacity").isEqualTo(150);
+        assertThat(queueSet.getFlushIntervalMs()).as("Flush interval").isEqualTo(1500);
+    }
+
+    @Test
+    void shutdown_flushesRemainingItems() throws Exception {
+        List<List<BulkIndexItem>> allBatches = Collections.synchronizedList(new ArrayList<>());
+
+        queueSet = new BulkQueueSet(2, 1000, 60_000, batch -> allBatches.add(new ArrayList<>(batch)));
+        queueSet.start();
+
+        queueSet.submit(BulkIndexItem.fireAndForget("idx", "d1", Map.of()));
+        queueSet.submit(BulkIndexItem.fireAndForget("idx", "d2", Map.of()));
+        queueSet.submit(BulkIndexItem.fireAndForget("idx", "d3", Map.of()));
+
+        queueSet.shutdown();
+        Thread.sleep(200);
+
+        int totalFlushed = allBatches.stream().mapToInt(List::size).sum();
+        assertThat(totalFlushed)
+                .as("Shutdown should flush remaining items")
+                .isEqualTo(3);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --tests '*BulkQueueSetTest*' --no-daemon 2>&1 | tail -20`
+Expected: FAIL — `BulkQueueSet` class does not exist
+
+- [ ] **Step 3: Implement BulkQueueSet**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Manages N concurrent {@link BulkIndexingQueue} instances with round-robin dispatch.
+ *
+ * <p>Thread safety: the {@code queues} array reference is volatile, enabling lock-free
+ * reads on the submit hot path. Resize creates a new array, drains old queues into new
+ * ones, and swaps the volatile reference.</p>
+ *
+ * <p>Lifecycle: call {@link #start()} after construction, {@link #shutdown()} on application stop.
+ * Shutdown flushes all remaining items before stopping timers.</p>
+ */
+public class BulkQueueSet {
+
+    private static final Logger LOG = Logger.getLogger(BulkQueueSet.class);
+
+    private volatile BulkIndexingQueue[] queues;
+    private volatile int capacity;
+    private volatile int flushIntervalMs;
+    private final Consumer<List<BulkIndexItem>> flushHandler;
+    private final AtomicInteger roundRobinCounter = new AtomicInteger();
+    private ScheduledExecutorService scheduler;
+
+    public BulkQueueSet(int queueCount, int capacity, int flushIntervalMs,
+                        Consumer<List<BulkIndexItem>> flushHandler) {
+        this.capacity = capacity;
+        this.flushIntervalMs = flushIntervalMs;
+        this.flushHandler = flushHandler;
+        this.queues = createQueues(queueCount, capacity, flushIntervalMs);
+    }
+
+    private BulkIndexingQueue[] createQueues(int count, int cap, int interval) {
+        BulkIndexingQueue[] arr = new BulkIndexingQueue[count];
+        for (int i = 0; i < count; i++) {
+            arr[i] = new BulkIndexingQueue(i, cap, interval, flushHandler);
+        }
+        return arr;
+    }
+
+    public void start() {
+        this.scheduler = Executors.newScheduledThreadPool(
+                Math.max(2, queues.length),
+                r -> {
+                    Thread t = new Thread(r, "bulk-queue-scheduler");
+                    t.setDaemon(true);
+                    return t;
+                });
+        for (BulkIndexingQueue q : queues) {
+            q.start(scheduler);
+        }
+        LOG.infof("BulkQueueSet started: %d queues, capacity=%d, flushInterval=%dms",
+                queues.length, capacity, flushIntervalMs);
+    }
+
+    /**
+     * Submit an item to the next queue (round-robin).
+     */
+    public void submit(BulkIndexItem item) {
+        BulkIndexingQueue[] current = this.queues;
+        int idx = Math.abs(roundRobinCounter.getAndIncrement() % current.length);
+        current[idx].submit(item);
+    }
+
+    /**
+     * Resize to a new queue count. Drains all items from old queues into new ones.
+     * In-flight OpenSearch bulk requests from old queues complete independently.
+     */
+    public void resize(int newQueueCount, int newCapacity, int newFlushIntervalMs) {
+        BulkIndexingQueue[] oldQueues = this.queues;
+        int oldCount = oldQueues.length;
+
+        BulkIndexingQueue[] newQueues = createQueues(newQueueCount, newCapacity, newFlushIntervalMs);
+        for (BulkIndexingQueue q : newQueues) {
+            q.start(scheduler);
+        }
+
+        // Atomic swap — new requests immediately go to new queues
+        this.queues = newQueues;
+        this.capacity = newCapacity;
+        this.flushIntervalMs = newFlushIntervalMs;
+
+        // Drain remaining items from old queues into new queues
+        AtomicInteger resubmitCounter = new AtomicInteger();
+        int totalDrained = 0;
+        for (BulkIndexingQueue oldQueue : oldQueues) {
+            List<BulkIndexItem> remaining = oldQueue.drainRemaining();
+            totalDrained += remaining.size();
+            for (BulkIndexItem item : remaining) {
+                int newIdx = Math.abs(resubmitCounter.getAndIncrement() % newQueues.length);
+                newQueues[newIdx].submit(item);
+            }
+            oldQueue.shutdown();
+        }
+
+        LOG.infof("BulkQueueSet resized: %d -> %d queues (capacity=%d, flush=%dms), drained %d items",
+                oldCount, newQueueCount, newCapacity, newFlushIntervalMs, totalDrained);
+    }
+
+    /**
+     * Force flush all queues immediately.
+     */
+    public void flushAll() {
+        for (BulkIndexingQueue q : queues) {
+            q.flush();
+        }
+    }
+
+    /**
+     * Shutdown: flush all remaining items, then stop timers.
+     */
+    public void shutdown() {
+        BulkIndexingQueue[] current = this.queues;
+        for (BulkIndexingQueue q : current) {
+            q.flush();
+            q.shutdown();
+        }
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+        LOG.info("BulkQueueSet shut down");
+    }
+
+    public int getQueueCount() {
+        return queues.length;
+    }
+
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public int getFlushIntervalMs() {
+        return flushIntervalMs;
+    }
+
+    /**
+     * Total pending items across all queues.
+     */
+    public int totalPending() {
+        int total = 0;
+        for (BulkIndexingQueue q : queues) {
+            total += q.pendingCount();
+        }
+        return total;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --tests '*BulkQueueSetTest*' --no-daemon 2>&1 | tail -20`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkQueueSet.java
+git add opensearch-manager/src/test/java/ai/pipestream/schemamanager/bulk/BulkQueueSetTest.java
+git commit -m "feat: add BulkQueueSet — N concurrent draining queues with round-robin and resize"
+```
+
+---
+
+## Task 6: BulkQueueSetBean — CDI-Managed Lifecycle with OpenSearch Flush Handler
+
+**Files:**
+- Create: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkQueueSetBean.java`
+
+This is the `@ApplicationScoped` CDI bean that wires `BulkQueueSet` to the `OpenSearchAsyncClient`. It owns the flush handler that builds `BulkRequest` objects and completes item futures from the `BulkResponse`.
+
+- [ ] **Step 1: Create BulkQueueSetBean**
+
+```java
+package ai.pipestream.schemamanager.bulk;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * CDI-managed wrapper for {@link BulkQueueSet}.
+ * Injects the OpenSearch client and wires the flush handler that builds
+ * and sends bulk requests, then completes per-item futures from the response.
+ */
+@ApplicationScoped
+public class BulkQueueSetBean {
+
+    private static final Logger LOG = Logger.getLogger(BulkQueueSetBean.class);
+
+    @Inject
+    OpenSearchAsyncClient openSearchAsyncClient;
+
+    @Inject
+    BulkIndexingConfig config;
+
+    private volatile BulkQueueSet queueSet;
+
+    void onStartup(@Observes StartupEvent event) {
+        queueSet = new BulkQueueSet(
+                config.queueCount(),
+                config.capacity(),
+                config.flushIntervalMs(),
+                this::handleFlush);
+        queueSet.start();
+        LOG.infof("BulkQueueSetBean started: %d queues, capacity=%d, flushInterval=%dms",
+                config.queueCount(), config.capacity(), config.flushIntervalMs());
+    }
+
+    void onShutdown(@Observes ShutdownEvent event) {
+        if (queueSet != null) {
+            queueSet.shutdown();
+        }
+    }
+
+    /**
+     * Submit an item for bulk indexing. Returns immediately.
+     * The item's resultFuture (if non-null) completes when the bulk flush processes it.
+     */
+    public void submit(BulkIndexItem item) {
+        queueSet.submit(item);
+    }
+
+    /**
+     * Submit and get a future for the result. Convenience for gRPC paths that need a response.
+     */
+    public CompletableFuture<BulkItemResult> submitWithFuture(String indexName, String docId,
+                                                               java.util.Map<String, Object> document,
+                                                               String routing) {
+        CompletableFuture<BulkItemResult> future = new CompletableFuture<>();
+        submit(new BulkIndexItem(indexName, docId, document, routing, future));
+        return future;
+    }
+
+    /**
+     * Fire-and-forget submit. Used for entity/telemetry indexing.
+     */
+    public void submitFireAndForget(String indexName, String docId, java.util.Map<String, Object> document) {
+        submit(BulkIndexItem.fireAndForget(indexName, docId, document));
+    }
+
+    /**
+     * Resize the queue set at runtime.
+     */
+    public void resize(int queueCount, int capacity, int flushIntervalMs) {
+        queueSet.resize(queueCount, capacity, flushIntervalMs);
+    }
+
+    public int getQueueCount() { return queueSet.getQueueCount(); }
+    public int getCapacity() { return queueSet.getCapacity(); }
+    public int getFlushIntervalMs() { return queueSet.getFlushIntervalMs(); }
+    public int totalPending() { return queueSet.totalPending(); }
+
+    /**
+     * Flush handler: builds a BulkRequest from the batch items, sends to OpenSearch,
+     * and completes each item's future from the per-item response.
+     */
+    private void handleFlush(List<BulkIndexItem> batch) {
+        try {
+            BulkRequest.Builder br = new BulkRequest.Builder();
+            for (BulkIndexItem item : batch) {
+                br.operations(op -> op.index(idx -> {
+                    idx.index(item.indexName())
+                       .id(item.docId())
+                       .document(item.document());
+                    if (item.routing() != null && !item.routing().isBlank()) {
+                        idx.routing(item.routing());
+                    }
+                    return idx;
+                }));
+            }
+
+            BulkResponse response = openSearchAsyncClient.bulk(br.build()).get();
+
+            if (response.errors()) {
+                long errorCount = response.items().stream()
+                        .filter(item -> item.error() != null).count();
+                LOG.warnf("Bulk flush had %d errors out of %d items", errorCount, batch.size());
+            } else {
+                LOG.debugf("Bulk flush succeeded: %d items", batch.size());
+            }
+
+            // Complete per-item futures
+            List<BulkResponseItem> items = response.items();
+            for (int i = 0; i < items.size() && i < batch.size(); i++) {
+                BulkResponseItem responseItem = items.get(i);
+                CompletableFuture<BulkItemResult> future = batch.get(i).resultFuture();
+                if (future != null) {
+                    if (responseItem.error() != null) {
+                        future.complete(BulkItemResult.failed(responseItem.error().reason()));
+                    } else {
+                        future.complete(BulkItemResult.ok());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.errorf(e, "Bulk flush failed for batch of %d items", batch.size());
+            for (BulkIndexItem item : batch) {
+                if (item.resultFuture() != null) {
+                    item.resultFuture().complete(BulkItemResult.failed("Bulk flush error: " + e.getMessage()));
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkQueueSetBean.java
+git commit -m "feat: add BulkQueueSetBean — CDI-managed lifecycle with OpenSearch bulk flush handler"
+```
+
+---
+
+## Task 7: Rewire OpenSearchIndexingService — Replace Entity Emitter with BulkQueueSet
+
+**Files:**
+- Modify: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchIndexingService.java` (lines 0-177)
+
+The entity emitter infrastructure (MultiEmitter + group + transformToUniAndConcatenate) is replaced with `BulkQueueSetBean.submitFireAndForget()`.
+
+- [ ] **Step 1: Replace entity emitter with BulkQueueSetBean injection**
+
+In `OpenSearchIndexingService.java`, make these changes:
+
+**Remove** these imports (no longer needed for entity batching):
+```java
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.BackPressureStrategy;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.event.Observes;
+import java.time.Duration;
+```
+
+**Remove** these fields and methods entirely:
+- Line 72: `private volatile MultiEmitter<? super EntityIndexRequest> entityEmitter;`
+- Lines 102: `record EntityIndexRequest(...) {}`
+- Lines 104-118: `void onStartup(@Observes StartupEvent event) { ... }`
+- Lines 120-124: `void onShutdown(@Observes ShutdownEvent event) { ... }`
+- Lines 139-168: `private Uni<Void> processEntityBatch(...) { ... }`
+- Lines 170-176: `private void indexEntityDirect(...) { ... }`
+
+**Add** this injection:
+```java
+@Inject
+ai.pipestream.schemamanager.bulk.BulkQueueSetBean bulkQueueSet;
+```
+
+**Replace** `queueForIndexing` method (lines 130-137):
+```java
+/**
+ * Queue a document for batched bulk indexing into OpenSearch.
+ * Fire-and-forget: the document will be included in the next bulk flush.
+ */
+public void queueForIndexing(String indexName, String docId, Map<String, Object> document) {
+    bulkQueueSet.submitFireAndForget(indexName, docId, document);
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --no-daemon 2>&1 | tail -30`
+Expected: All existing tests pass (entity indexing still works through the new path)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchIndexingService.java
+git commit -m "refactor: replace entity emitter pipeline with BulkQueueSetBean in OpenSearchIndexingService"
+```
+
+---
+
+## Task 8: Rewire NestedIndexingStrategy — Bulk Queue for Document Indexing
+
+**Files:**
+- Modify: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/NestedIndexingStrategy.java` (lines 505-540)
+
+Replace `indexDocumentToOpenSearchViaRest()` which calls `openSearchAsyncClient.index()` with `bulkQueueSet.submitWithFuture()`.
+
+- [ ] **Step 1: Add BulkQueueSetBean injection**
+
+Add to NestedIndexingStrategy (after line 40, the ObjectMapper injection):
+```java
+@Inject
+ai.pipestream.schemamanager.bulk.BulkQueueSetBean bulkQueueSet;
+```
+
+- [ ] **Step 2: Replace indexDocumentToOpenSearchViaRest**
+
+Replace the method at lines 511-540 with:
+```java
+private Uni<BulkIndexOutcome> indexDocumentToOpenSearchViaRest(String indexName, String documentId, String jsonDoc, String routing) {
+    Map<String, Object> docMap;
+    try {
+        docMap = objectMapper.readValue(jsonDoc, new TypeReference<>() {});
+    } catch (IOException e) {
+        return Uni.createFrom().item(new BulkIndexOutcome(false, "JSON parse: " + e.getMessage()));
+    }
+
+    return Uni.createFrom().completionStage(
+            bulkQueueSet.submitWithFuture(indexName, documentId, docMap, routing)
+    ).map(result -> {
+        if (result.success()) {
+            return BulkIndexOutcome.ok();
+        }
+        return new BulkIndexOutcome(false, result.failureDetail());
+    });
+}
+```
+
+**Remove** the now-unused `runSubscriptionOn(Infrastructure.getDefaultWorkerPool())` call and the single-doc `IndexRequest.Builder` usage. Remove unused imports: `java.util.concurrent.ExecutionException`.
+
+- [ ] **Step 3: Also replace indexDocumentsIndividuallyFallback to use bulk queue**
+
+The `indexDocumentsIndividuallyFallback` method (lines 119-156) calls `indexDocumentToOpenSearch` for each item individually. Since the queue handles batching, this is fine — each submit goes to the queue and the queue batches them together in the next flush.
+
+No change needed here — it already calls `indexDocumentToOpenSearch` → `indexDocumentToOpenSearchViaRest` which now uses the queue.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --no-daemon 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/NestedIndexingStrategy.java
+git commit -m "refactor: route NestedIndexingStrategy document indexing through BulkQueueSet"
+```
+
+---
+
+## Task 9: Rewire ChunkCombinedIndexingStrategy — Bulk Queue for Base + Chunk Indexing
+
+**Files:**
+- Modify: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/ChunkCombinedIndexingStrategy.java` (lines 143-178 and 430-461)
+
+Replace `indexBaseDocument()` single-doc index call and `bulkIndexChunkDocs()` manual BulkRequest with `bulkQueueSet.submitWithFuture()`.
+
+- [ ] **Step 1: Add BulkQueueSetBean injection**
+
+Add to ChunkCombinedIndexingStrategy (after line 35, the ObjectMapper injection):
+```java
+@Inject
+ai.pipestream.schemamanager.bulk.BulkQueueSetBean bulkQueueSet;
+```
+
+- [ ] **Step 2: Replace indexBaseDocument**
+
+Replace the method at lines 143-178:
+```java
+private Uni<IndexOutcome> indexBaseDocument(String indexName, String documentId, OpenSearchDocumentMap docMap) {
+    return Uni.createFrom().item(() -> {
+        try {
+            ensureBaseIndex(indexName);
+
+            String jsonDoc = JsonFormat.printer()
+                    .preservingProtoFieldNames()
+                    .print(docMap);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> docAsMap = objectMapper.readValue(jsonDoc, Map.class);
+            sanitizePunctuationCounts(docAsMap);
+            return docAsMap;
+        } catch (Exception e) {
+            return null; // signal failure
+        }
+    }).runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
+      .flatMap(docAsMap -> {
+          if (docAsMap == null) {
+              return Uni.createFrom().item(new IndexOutcome(false, "Failed to serialize base document"));
+          }
+          return Uni.createFrom().completionStage(
+                  bulkQueueSet.submitWithFuture(indexName, documentId, docAsMap, null)
+          ).map(result -> {
+              if (result.success()) {
+                  LOG.infof("CHUNK_COMBINED: base document queued for bulk index to %s/%s", indexName, documentId);
+                  return IndexOutcome.ok();
+              }
+              return new IndexOutcome(false, result.failureDetail());
+          });
+      });
+}
+```
+
+- [ ] **Step 3: Replace bulkIndexChunkDocs**
+
+Replace the method at lines 430-461:
+```java
+private Uni<Boolean> bulkIndexChunkDocs(String chunkIndexName, List<OpenSearchChunkDocument> chunks) {
+    // Submit each chunk to the bulk queue
+    List<java.util.concurrent.CompletableFuture<ai.pipestream.schemamanager.bulk.BulkItemResult>> futures = new ArrayList<>();
+    for (OpenSearchChunkDocument chunk : chunks) {
+        Map<String, Object> docMap = serializeChunkDocument(chunk);
+        String docId = generateChunkDocId(chunk);
+        futures.add(bulkQueueSet.submitWithFuture(chunkIndexName, docId, docMap, null));
+    }
+
+    // Wait for all chunk futures to complete
+    return Uni.createFrom().completionStage(
+            java.util.concurrent.CompletableFuture.allOf(futures.toArray(new java.util.concurrent.CompletableFuture[0]))
+                    .thenApply(v -> {
+                        long failCount = futures.stream()
+                                .map(java.util.concurrent.CompletableFuture::join)
+                                .filter(r -> !r.success())
+                                .count();
+                        if (failCount > 0) {
+                            LOG.warnf("CHUNK_COMBINED: %d/%d chunks failed for %s", failCount, chunks.size(), chunkIndexName);
+                        }
+                        return failCount < chunks.size(); // true if at least some succeeded
+                    })
+    );
+}
+```
+
+**Remove** the now-unused direct `openSearchAsyncClient.bulk()` call and `BulkRequest.Builder` import from this method. The `openSearchAsyncClient` injection can stay since `ensureBaseIndex`, `ensureChunkIndex`, and `ensureFlatKnnField` still use it directly for schema operations.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --no-daemon 2>&1 | tail -30`
+Expected: All tests pass (including ChunkCombinedIndexingStrategyTest)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/ChunkCombinedIndexingStrategy.java
+git commit -m "refactor: route ChunkCombined base+chunk indexing through BulkQueueSet"
+```
+
+---
+
+## Task 10: gRPC Handlers — GetBulkConfig and UpdateBulkConfig
+
+**Files:**
+- Modify: `opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchManagerService.java`
+
+- [ ] **Step 1: Add BulkQueueSetBean injection and imports**
+
+Add to OpenSearchManagerService:
+```java
+@Inject
+ai.pipestream.schemamanager.bulk.BulkQueueSetBean bulkQueueSet;
+```
+
+Add imports:
+```java
+import ai.pipestream.opensearch.v1.BulkIndexingConfig;
+import ai.pipestream.opensearch.v1.GetBulkConfigRequest;
+import ai.pipestream.opensearch.v1.GetBulkConfigResponse;
+import ai.pipestream.opensearch.v1.UpdateBulkConfigRequest;
+import ai.pipestream.opensearch.v1.UpdateBulkConfigResponse;
+```
+
+- [ ] **Step 2: Add GetBulkConfig handler**
+
+```java
+@Override
+public Uni<GetBulkConfigResponse> getBulkConfig(GetBulkConfigRequest request) {
+    return Uni.createFrom().item(() ->
+            GetBulkConfigResponse.newBuilder()
+                    .setConfig(BulkIndexingConfig.newBuilder()
+                            .setQueueCount(bulkQueueSet.getQueueCount())
+                            .setQueueCapacity(bulkQueueSet.getCapacity())
+                            .setFlushIntervalMs(bulkQueueSet.getFlushIntervalMs())
+                            .build())
+                    .build());
+}
+```
+
+- [ ] **Step 3: Add UpdateBulkConfig handler**
+
+```java
+@Override
+public Uni<UpdateBulkConfigResponse> updateBulkConfig(UpdateBulkConfigRequest request) {
+    return Uni.createFrom().item(() -> {
+        var cfg = request.getConfig();
+        int queueCount = cfg.getQueueCount();
+        int capacity = cfg.getQueueCapacity();
+        int flushMs = cfg.getFlushIntervalMs();
+
+        // Validate ranges
+        if (queueCount < 2 || queueCount > 10) {
+            return UpdateBulkConfigResponse.newBuilder()
+                    .setSuccess(false)
+                    .setMessage("queue_count must be between 2 and 10, got " + queueCount)
+                    .build();
+        }
+        if (capacity < 10 || capacity > 5000) {
+            return UpdateBulkConfigResponse.newBuilder()
+                    .setSuccess(false)
+                    .setMessage("queue_capacity must be between 10 and 5000, got " + capacity)
+                    .build();
+        }
+        if (flushMs < 100 || flushMs > 30000) {
+            return UpdateBulkConfigResponse.newBuilder()
+                    .setSuccess(false)
+                    .setMessage("flush_interval_ms must be between 100 and 30000, got " + flushMs)
+                    .build();
+        }
+
+        bulkQueueSet.resize(queueCount, capacity, flushMs);
+
+        LOG.infof("Bulk indexing config updated: queues=%d, capacity=%d, flushMs=%d",
+                queueCount, capacity, flushMs);
+
+        return UpdateBulkConfigResponse.newBuilder()
+                .setSuccess(true)
+                .setActiveConfig(BulkIndexingConfig.newBuilder()
+                        .setQueueCount(bulkQueueSet.getQueueCount())
+                        .setQueueCapacity(bulkQueueSet.getCapacity())
+                        .setFlushIntervalMs(bulkQueueSet.getFlushIntervalMs())
+                        .build())
+                .setMessage("Bulk indexing config updated successfully")
+                .build();
+    });
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:compileJava`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/core-services/pipestream-opensearch
+git add opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchManagerService.java
+git commit -m "feat: add GetBulkConfig and UpdateBulkConfig gRPC handlers"
+```
+
+---
+
+## Task 11: Full Test Suite Verification
+
+- [ ] **Step 1: Run full opensearch-manager test suite**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew :opensearch-manager:test --no-daemon 2>&1 | tail -40`
+Expected: All tests PASS. If any fail, fix them before proceeding.
+
+- [ ] **Step 2: Run full pipestream-opensearch build (all subprojects)**
+
+Run: `cd /work/core-services/pipestream-opensearch && ./gradlew clean build --no-daemon 2>&1 | tail -40`
+Expected: BUILD SUCCESSFUL for all subprojects
+
+- [ ] **Step 3: Commit any fixes**
+
+If any tests needed fixes, commit them individually with descriptive messages.
+
+---
+
+## Task 12: Final Commit and Push
+
+- [ ] **Step 1: Review all changes**
+
+Run: `cd /work/core-services/pipestream-opensearch && git log --oneline -10` to verify commit history.
+Run: `cd /work/core-services/pipestream-opensearch && git diff main --stat` to see all changed files.
+
+- [ ] **Step 2: Squash or keep commits (user preference)**
+
+Ask the user if they want to squash into a single commit or keep the incremental history.
+
+- [ ] **Step 3: Push**
+
+Only push when the user confirms.

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchIndexingService.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/OpenSearchIndexingService.java
@@ -22,6 +22,7 @@ import com.google.protobuf.util.JsonFormat;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import ai.pipestream.schemamanager.config.OpenSearchManagerRuntimeConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import io.vertx.core.Context;
@@ -65,6 +66,9 @@ public class OpenSearchIndexingService {
 
     @Inject
     ai.pipestream.schemamanager.bulk.BulkQueueSetBean bulkQueueSet;
+
+    @Inject
+    OpenSearchManagerRuntimeConfig managerRuntimeConfig;
 
     public Uni<IndexDocumentResponse> indexDocument(IndexDocumentRequest request) {
         IndexingStrategyHandler strategy = resolveStrategy(request.getIndexingStrategy());
@@ -743,6 +747,13 @@ public class OpenSearchIndexingService {
 
         return Uni.createFrom().item(() -> {
             try {
+                if (managerRuntimeConfig.indexStats().refreshBeforeRead()) {
+                    try {
+                        openSearchAsyncClient.indices().refresh(r -> r.index(indexName)).get();
+                    } catch (Exception e) {
+                        LOG.warnf("Refresh before stats failed for index '%s': %s", indexName, e.getMessage());
+                    }
+                }
                 var statsResponse = openSearchAsyncClient.indices()
                         .stats(b -> b.index(indexName)).get();
 

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/VectorSetServiceEngine.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/VectorSetServiceEngine.java
@@ -1,5 +1,6 @@
 package ai.pipestream.schemamanager;
 
+import ai.pipestream.data.v1.GranularityLevel;
 import ai.pipestream.opensearch.v1.*;
 import ai.pipestream.schemamanager.config.SemanticVectorSetConfig;
 import ai.pipestream.schemamanager.entity.ChunkerConfigEntity;
@@ -106,9 +107,9 @@ public class VectorSetServiceEngine {
                                                     }
                                                     entity.semanticConfig = sc;
                                                     if (request.hasGranularity()
-                                                            && request.getGranularity() != SemanticGranularity.SEMANTIC_GRANULARITY_UNSPECIFIED) {
+                                                            && request.getGranularity() != GranularityLevel.GRANULARITY_LEVEL_UNSPECIFIED) {
                                                         entity.granularity = request.getGranularity().name()
-                                                                .replace("SEMANTIC_GRANULARITY_", "");
+                                                                .replace("GRANULARITY_LEVEL_", "");
                                                     }
                                                     return persistAndBind(entity, request.getIndexName());
                                                 });
@@ -507,14 +508,14 @@ public class VectorSetServiceEngine {
         return b.build();
     }
 
-    private static SemanticGranularity mapGranularity(String g) {
+    private static GranularityLevel mapGranularity(String g) {
         return switch (g) {
-            case "SEMANTIC_CHUNK" -> SemanticGranularity.SEMANTIC_GRANULARITY_SEMANTIC_CHUNK;
-            case "SENTENCE" -> SemanticGranularity.SEMANTIC_GRANULARITY_SENTENCE;
-            case "PARAGRAPH" -> SemanticGranularity.SEMANTIC_GRANULARITY_PARAGRAPH;
-            case "SECTION" -> SemanticGranularity.SEMANTIC_GRANULARITY_SECTION;
-            case "DOCUMENT" -> SemanticGranularity.SEMANTIC_GRANULARITY_DOCUMENT;
-            default -> SemanticGranularity.SEMANTIC_GRANULARITY_UNSPECIFIED;
+            case "SEMANTIC_CHUNK" -> GranularityLevel.GRANULARITY_LEVEL_SEMANTIC_CHUNK;
+            case "SENTENCE" -> GranularityLevel.GRANULARITY_LEVEL_SENTENCE;
+            case "PARAGRAPH" -> GranularityLevel.GRANULARITY_LEVEL_PARAGRAPH;
+            case "SECTION" -> GranularityLevel.GRANULARITY_LEVEL_SECTION;
+            case "DOCUMENT" -> GranularityLevel.GRANULARITY_LEVEL_DOCUMENT;
+            default -> GranularityLevel.GRANULARITY_LEVEL_UNSPECIFIED;
         };
     }
 

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingConfig.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkIndexingConfig.java
@@ -10,7 +10,7 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "bulk-indexing")
 public interface BulkIndexingConfig {
 
-    /** Number of concurrent draining queues. Range: 2-10. */
+    /** Number of concurrent draining queues. Runtime updates must stay within 2–32 (see UpdateBulkConfig). */
     @WithDefault("4")
     int queueCount();
 

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkQueueSetBean.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/bulk/BulkQueueSetBean.java
@@ -13,6 +13,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 @ApplicationScoped
@@ -74,6 +75,10 @@ public class BulkQueueSetBean {
 
     /**
      * Flush handler: builds a BulkRequest, sends to OpenSearch, completes per-item futures.
+     * Uses blocking {@code .get()} so completion runs before {@code flush()} returns — required so
+     * per-item {@link CompletableFuture}s are finished on the bulk scheduler thread (not the HTTP
+     * client I/O thread), avoiding stalls when multiple {@code indexDocument} calls run Mutiny chains
+     * off bulk completions.
      */
     private void handleFlush(List<BulkIndexItem> batch) {
         try {
@@ -100,17 +105,29 @@ public class BulkQueueSetBean {
                 LOG.debugf("Bulk flush succeeded: %d items", batch.size());
             }
 
-            // Complete per-item futures
             List<BulkResponseItem> items = response.items();
-            for (int i = 0; i < items.size() && i < batch.size(); i++) {
+            int n = Math.min(items.size(), batch.size());
+            for (int i = 0; i < n; i++) {
                 BulkResponseItem responseItem = items.get(i);
                 CompletableFuture<BulkItemResult> future = batch.get(i).resultFuture();
+                var opError = responseItem.error();
                 if (future != null) {
-                    if (responseItem.error() != null) {
-                        future.complete(BulkItemResult.failed(responseItem.error().reason()));
+                    if (opError != null) {
+                        future.complete(BulkItemResult.failed(
+                                Objects.toString(opError.reason(), "bulk item error")));
                     } else {
                         future.complete(BulkItemResult.ok());
                     }
+                }
+            }
+            if (items.size() != batch.size()) {
+                LOG.errorf("Bulk response size mismatch: ops=%d batch=%d — completing missing futures as failed",
+                        items.size(), batch.size());
+            }
+            for (int i = n; i < batch.size(); i++) {
+                CompletableFuture<BulkItemResult> future = batch.get(i).resultFuture();
+                if (future != null && !future.isDone()) {
+                    future.complete(BulkItemResult.failed("missing bulk response item"));
                 }
             }
         } catch (Exception e) {

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/config/OpenSearchManagerRuntimeConfig.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/config/OpenSearchManagerRuntimeConfig.java
@@ -1,0 +1,33 @@
+package ai.pipestream.schemamanager.config;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Non–OpenSearch-client settings for opensearch-manager application behavior.
+ */
+@ConfigMapping(prefix = "opensearch-manager")
+public interface OpenSearchManagerRuntimeConfig {
+
+    SemanticMetadata semanticMetadata();
+
+    IndexStats indexStats();
+
+    interface SemanticMetadata {
+        /**
+         * When true, a failed Kafka send for semantic-metadata-events is logged but does not fail
+         * chunker / embedding CRUD (avoids gRPC UNKNOWN when the broker is down locally).
+         */
+        @WithDefault("false")
+        boolean failOpenPublish();
+    }
+
+    interface IndexStats {
+        /**
+         * When true, forces an index refresh before reading primaries doc count (helps when
+         * {@code refresh_interval} is {@code -1}).
+         */
+        @WithDefault("false")
+        boolean refreshBeforeRead();
+    }
+}

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/ChunkCombinedIndexingStrategy.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/ChunkCombinedIndexingStrategy.java
@@ -2,7 +2,6 @@ package ai.pipestream.schemamanager.indexing;
 
 import ai.pipestream.opensearch.v1.*;
 import ai.pipestream.schemamanager.opensearch.OpenSearchSchemaService;
-import ai.pipestream.schemamanager.v1.VectorFieldDefinition;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.util.JsonFormat;
 import io.smallrye.mutiny.Uni;
@@ -468,6 +467,8 @@ public class ChunkCombinedIndexingStrategy implements IndexingStrategyHandler {
             futures.add(bulkQueueSet.submitWithFuture(chunkIndexName, docId, docMap, null));
         }
 
+        // Run subscription on worker pool so bulk CompletableFuture completion (from BulkQueueSetBean)
+        // does not drive downstream Mutiny operators on the HTTP client I/O thread under concurrent indexDocument.
         return Uni.createFrom().completionStage(
                 java.util.concurrent.CompletableFuture.allOf(futures.toArray(new java.util.concurrent.CompletableFuture[0]))
                         .thenApply(v -> {
@@ -480,7 +481,7 @@ public class ChunkCombinedIndexingStrategy implements IndexingStrategyHandler {
                             }
                             return failCount < chunks.size();
                         })
-        );
+        ).runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
     }
 
     // ===== Chunk document serialization =====

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/NestedIndexingStrategy.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/indexing/NestedIndexingStrategy.java
@@ -1,7 +1,7 @@
 package ai.pipestream.schemamanager.indexing;
 
+import ai.pipestream.data.v1.GranularityLevel;
 import ai.pipestream.opensearch.v1.*;
-import ai.pipestream.opensearch.v1.SemanticGranularity;
 import ai.pipestream.schemamanager.entity.ChunkerConfigEntity;
 import ai.pipestream.schemamanager.entity.EmbeddingModelConfig;
 import ai.pipestream.schemamanager.entity.VectorSetEntity;
@@ -342,8 +342,8 @@ public class NestedIndexingStrategy implements IndexingStrategyHandler {
                 // Path: Semantic config — lookup by (semantic_config_id, granularity)
                 if (vset.hasSemanticConfigId() && !vset.getSemanticConfigId().isBlank()
                         && vset.hasGranularity()
-                        && vset.getGranularity() != SemanticGranularity.SEMANTIC_GRANULARITY_UNSPECIFIED) {
-                    String granStr = vset.getGranularity().name().replace("SEMANTIC_GRANULARITY_", "");
+                        && vset.getGranularity() != GranularityLevel.GRANULARITY_LEVEL_UNSPECIFIED) {
+                    String granStr = vset.getGranularity().name().replace("GRANULARITY_LEVEL_", "");
                     return VectorSetEntity.findBySemanticConfigAndGranularity(vset.getSemanticConfigId(), granStr)
                             .onItem().transformToUni(entity -> {
                                 if (entity == null) {

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/kafka/PipelineEventConsumer.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/kafka/PipelineEventConsumer.java
@@ -2,7 +2,6 @@ package ai.pipestream.schemamanager.kafka;
 
 import ai.pipestream.data.v1.StepExecutionRecord;
 import ai.pipestream.schemamanager.OpenSearchIndexingService;
-import ai.pipestream.schemamanager.opensearch.IndexConstants.Index;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.Record;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -13,7 +12,9 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -26,6 +27,10 @@ public class PipelineEventConsumer {
 
     private static final Logger LOG = Logger.getLogger(PipelineEventConsumer.class);
     private static final DateTimeFormatter MONTH_FORMAT = DateTimeFormatter.ofPattern("yyyy.MM");
+    private static final String SEMANTIC_TELEMETRY_PREFIX = "telemetry semantic_manager ";
+    private static final int MAX_STORED_LOG_ENTRIES = 40;
+    private static final int MAX_TOTAL_LOG_CHARS = 12_000;
+    private static final int MAX_LOG_MESSAGE_CHARS = 1_000;
 
     @Inject
     OpenSearchIndexingService indexingService;
@@ -66,6 +71,11 @@ public class PipelineEventConsumer {
 
         if (step.getLogEntriesCount() > 0) {
             document.put("log_entry_count", step.getLogEntriesCount());
+            document.putAll(extractCappedLogEntries(step));
+        }
+        Map<String, Object> semanticTelemetry = extractSemanticTelemetry(step);
+        if (!semanticTelemetry.isEmpty()) {
+            document.put("semantic_manager_telemetry", semanticTelemetry);
         }
 
         // Monthly rollover index
@@ -75,5 +85,117 @@ public class PipelineEventConsumer {
 
         indexingService.queueForIndexing(indexName, key.toString(), document);
         return Uni.createFrom().voidItem();
+    }
+
+    private Map<String, Object> extractSemanticTelemetry(StepExecutionRecord step) {
+        for (int i = step.getLogEntriesCount() - 1; i >= 0; i--) {
+            String message = step.getLogEntries(i).getMessage();
+            if (message == null || !message.startsWith(SEMANTIC_TELEMETRY_PREFIX)) {
+                continue;
+            }
+            String payload = message.substring(SEMANTIC_TELEMETRY_PREFIX.length()).trim();
+            if (payload.isEmpty()) {
+                return Map.of();
+            }
+            Map<String, Object> parsed = new HashMap<>();
+            String[] tokens = payload.split("\\s+");
+            for (String token : tokens) {
+                int separator = token.indexOf('=');
+                if (separator <= 0 || separator == token.length() - 1) {
+                    continue;
+                }
+                String key = token.substring(0, separator);
+                String rawValue = token.substring(separator + 1);
+                Object value = rawValue;
+                if (rawValue.matches("-?\\d+")) {
+                    try {
+                        value = Long.parseLong(rawValue);
+                    } catch (NumberFormatException ignored) {
+                        // Keep original string if parsing fails.
+                    }
+                }
+                parsed.put(key, value);
+            }
+            return parsed;
+        }
+        return Map.of();
+    }
+
+    private Map<String, Object> extractCappedLogEntries(StepExecutionRecord step) {
+        List<Map<String, Object>> storedLogs = new ArrayList<>();
+        int totalStoredChars = 0;
+        int droppedCount = 0;
+        boolean anyTruncated = false;
+
+        for (int i = 0; i < step.getLogEntriesCount(); i++) {
+            if (storedLogs.size() >= MAX_STORED_LOG_ENTRIES) {
+                droppedCount += (step.getLogEntriesCount() - i);
+                break;
+            }
+
+            var entry = step.getLogEntries(i);
+            String message = entry.getMessage();
+            if (message == null) {
+                message = "";
+            }
+
+            boolean messageTruncated = false;
+            if (message.length() > MAX_LOG_MESSAGE_CHARS) {
+                message = truncateWithSuffix(message, MAX_LOG_MESSAGE_CHARS);
+                messageTruncated = true;
+                anyTruncated = true;
+            }
+
+            int remainingChars = MAX_TOTAL_LOG_CHARS - totalStoredChars;
+            if (remainingChars <= 0) {
+                droppedCount += (step.getLogEntriesCount() - i);
+                anyTruncated = true;
+                break;
+            }
+
+            if (message.length() > remainingChars) {
+                message = truncateWithSuffix(message, remainingChars);
+                messageTruncated = true;
+                anyTruncated = true;
+            }
+
+            Map<String, Object> indexedLog = new HashMap<>();
+            indexedLog.put("timestamp_epoch_ms", entry.getTimestampEpochMs());
+            indexedLog.put("level", entry.getLevel().name());
+            indexedLog.put("source", entry.getSource().name());
+            indexedLog.put("message", message);
+            if (messageTruncated) {
+                indexedLog.put("message_truncated", true);
+            }
+            if (entry.hasModule()) {
+                indexedLog.put("module_name", entry.getModule().getModuleName());
+            }
+            if (entry.hasEngine()) {
+                indexedLog.put("engine_node_id", entry.getEngine().getNodeId());
+            }
+
+            storedLogs.add(indexedLog);
+            totalStoredChars += message.length();
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("log_entries", storedLogs);
+        result.put("log_entries_stored_count", storedLogs.size());
+        result.put("log_entries_dropped_count", droppedCount);
+        result.put("log_entries_total_chars", totalStoredChars);
+        if (anyTruncated) {
+            result.put("log_entries_truncated", true);
+        }
+        return result;
+    }
+
+    private String truncateWithSuffix(String value, int maxChars) {
+        if (value.length() <= maxChars) {
+            return value;
+        }
+        if (maxChars <= 3) {
+            return value.substring(0, Math.max(0, maxChars));
+        }
+        return value.substring(0, maxChars - 3) + "...";
     }
 }

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/kafka/SemanticMetadataEventProducer.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/kafka/SemanticMetadataEventProducer.java
@@ -2,9 +2,11 @@ package ai.pipestream.schemamanager.kafka;
 
 import ai.pipestream.opensearch.v1.*;
 import com.google.protobuf.Timestamp;
+import ai.pipestream.schemamanager.config.OpenSearchManagerRuntimeConfig;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.MutinyEmitter;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.jboss.logging.Logger;
 
@@ -21,8 +23,14 @@ public class SemanticMetadataEventProducer {
 
     private final MutinyEmitter<SemanticMetadataEvent> emitter;
 
-    public SemanticMetadataEventProducer(@Channel("semantic-metadata-events") MutinyEmitter<SemanticMetadataEvent> emitter) {
+    private final boolean failOpenPublish;
+
+    @Inject
+    public SemanticMetadataEventProducer(
+            @Channel("semantic-metadata-events") MutinyEmitter<SemanticMetadataEvent> emitter,
+            OpenSearchManagerRuntimeConfig runtimeConfig) {
         this.emitter = emitter;
+        this.failOpenPublish = runtimeConfig.semanticMetadata().failOpenPublish();
     }
 
     public Uni<Void> publishChunkerConfigCreated(ChunkerConfig config) {
@@ -110,7 +118,12 @@ public class SemanticMetadataEventProducer {
                 .build();
         SemanticMetadataEvent.Builder b = event != null ? event.toBuilder() : SemanticMetadataEvent.newBuilder();
         SemanticMetadataEvent full = b.setEventType(eventType).setEntityId(entityId).setOccurredAt(now).build();
-        return emitter.send(full).replaceWithVoid().onFailure().invoke(e ->
-                LOG.warnf(e, "Failed to publish semantic metadata event %s for %s", eventType, entityId));
+        Uni<Void> send = emitter.send(full).replaceWithVoid()
+                .onFailure().invoke(e ->
+                        LOG.warnf(e, "Failed to publish semantic metadata event %s for %s", eventType, entityId));
+        if (failOpenPublish) {
+            return send.onFailure().recoverWithUni(() -> Uni.createFrom().voidItem());
+        }
+        return send;
     }
 }

--- a/opensearch-manager/src/main/resources/application.properties
+++ b/opensearch-manager/src/main/resources/application.properties
@@ -66,6 +66,14 @@ quarkus.log.category."io.vertx.ext.consul".level=WARN
 opensearch.protocol=${OPENSEARCH_PROTOCOL:http}
 opensearch.username=${OPENSEARCH_USERNAME:}
 opensearch.password=${OPENSEARCH_PASSWORD:}
+# Throughput: defaults (20 total / 10 per route) stall under concurrent CHUNK_COMBINED indexDocument calls
+opensearch.max-connections=${OPENSEARCH_MAX_CONNECTIONS:64}
+opensearch.max-connections-per-route=${OPENSEARCH_MAX_CONNECTIONS_PER_ROUTE:32}
+# Large bulks can exceed 10s; align with client and avoid spurious failures under load
+opensearch.socket-timeout=${OPENSEARCH_SOCKET_TIMEOUT_MS:120000}
+# E2E / dev: knn index may use refresh_interval=-1; refresh makes doc counts visible for getIndexStats
+opensearch-manager.index-stats.refresh-before-read=${OPENSEARCH_INDEX_STATS_REFRESH_BEFORE_READ:false}
+%dev.opensearch-manager.index-stats.refresh-before-read=true
 
 # Schema manager specific configuration
 schema.manager.lock.timeout=PT10S
@@ -108,6 +116,9 @@ mp.messaging.incoming.document-uploaded-events-in.topic=document-uploaded-events
 # Semantic metadata events - published when ChunkerConfig, EmbeddingModelConfig, or IndexEmbeddingBinding change
 mp.messaging.outgoing.semantic-metadata-events.connector=smallrye-kafka
 mp.messaging.outgoing.semantic-metadata-events.topic=semantic-metadata-events
+# Local E2E often has no Kafka; when false, a failed publish fails createChunkerConfig (gRPC UNKNOWN without description)
+opensearch-manager.semantic-metadata.fail-open-publish=${OPENSEARCH_SEMANTIC_METADATA_FAIL_OPEN_PUBLISH:false}
+%dev.opensearch-manager.semantic-metadata.fail-open-publish=true
 
 # ======================================================================================================================
 # KNN Vector Index Creation Settings
@@ -126,9 +137,9 @@ knn-index.hnsw-m=16
 # ======================================================================================================================
 # Bulk Indexing Queue Configuration
 # ======================================================================================================================
-# Number of concurrent draining queues
-bulk-indexing.queue-count=9
-# Maximum items per queue before forced flush
-bulk-indexing.capacity=200
-# Milliseconds between periodic flush sweeps
-bulk-indexing.flush-interval-ms=2000
+# Number of concurrent draining queues (more = less head-of-line blocking per queue)
+bulk-indexing.queue-count=${BULK_QUEUE_COUNT:16}
+# Larger batches = fewer HTTP round-trips for the same chunk volume
+bulk-indexing.capacity=${BULK_QUEUE_CAPACITY:400}
+# Periodic flush sweep
+bulk-indexing.flush-interval-ms=${BULK_FLUSH_INTERVAL_MS:1000}


### PR DESCRIPTION
## Summary

Two independent fixes in one branch:

### 1. Bulk indexing stall under concurrent CHUNK_COMBINED calls (62201e2)

Root cause: the HTTP client I/O thread was driving downstream Mutiny operators via bulk completion futures, which blocked the same I/O thread when multiple `indexDocument` calls overlapped. Under load this presented as a complete stall.

- `BulkQueueSetBean.handleFlush` now uses blocking `.get()` so per-item futures complete on the bulk scheduler thread, not the HTTP I/O thread
- `ChunkCombinedIndexingStrategy.indexChunks` wraps the aggregation with `runSubscriptionOn(Infrastructure.getDefaultWorkerPool())`
- Null-safety on `responseItem.error().reason()` via `Objects.toString`
- Handle bulk response size mismatch: complete missing futures as failed rather than hanging
- Connection pool defaults: `max-connections=64`, `max-connections-per-route=32`, `socket-timeout=120s` (all env-overridable)
- Bulk queue defaults: queue-count 9→16, capacity 200→400, flush-interval 2000→1000ms (all env-overridable)
- New dev-only feature flags: `opensearch-manager.index-stats.refresh-before-read` (forces refresh before reading primaries doc count when `refresh_interval=-1`) and `opensearch-manager.semantic-metadata.fail-open-publish` (lets local dev runs without Kafka succeed at chunker/embedding CRUD)
- `PipelineEventConsumer` now extracts structured `semantic_manager_telemetry` from log entries prefixed `"telemetry semantic_manager "` and caps stored log entries at 40 per step / 12KB total / 1KB per message with truncation markers — prevents unbounded storage bloat
- New `OpenSearchManagerRuntimeConfig` ConfigMapping interface backs the two feature flags

### 2. SemanticGranularity → GranularityLevel consolidation (6394bad)

The `ai.pipestream.opensearch.v1.SemanticGranularity` enum was a duplicate of the new `ai.pipestream.data.v1.GranularityLevel` enum added to the common bufmodule in [pipestream-protos#31](https://github.com/ai-pipestream/pipestream-protos/pull/31). Both had the same 6 values with the same integer assignments. Keeping them both would permanently lock in the vocabulary fragmentation that PR #31 set out to fix.

The proto side of the consolidation is in commit [a35c5c8](https://github.com/ai-pipestream/pipestream-protos/commit/a35c5c8) on the pipestream-protos PR #31 branch. This repo just needs the matching Java import updates:

- `VectorSetServiceEngine.java`: add `import ai.pipestream.data.v1.GranularityLevel`, swap `SemanticGranularity.SEMANTIC_GRANULARITY_*` → `GranularityLevel.GRANULARITY_LEVEL_*` (3 sites), update the `.replace("SEMANTIC_GRANULARITY_", "")` prefix, change `mapGranularity` return type
- `NestedIndexingStrategy.java`: swap explicit import, same UNSPECIFIED guard and `.replace()` prefix updates

The switch arm string keys (`"SEMANTIC_CHUNK"`, `"SENTENCE"`, etc.) are unchanged because they come from the stored `VectorSetEntity.granularity` column, not from the enum name.

### 3. Temporary gitRef pin (part of commit 6394bad)

`opensearch-manager/build.gradle` pins `pipestreamProtos.gitRef` to `proto/quality-and-classification` (both the local `file://` and HTTPS fallback) so the proto regen picks up the consolidated enum. Revert to `"main"` after pipestream-protos#31 merges and the rollout completes. Comment in the file documents the intent.

## Test plan

- [x] `./gradlew :opensearch-manager:compileJava --rerun-tasks` — BUILD SUCCESSFUL (forces proto regen from the updated branch)
- [x] `./gradlew :opensearch-manager:test` — BUILD SUCCESSFUL, all suites green
  - Ran with `opensearch-manager/.env` moved to `.env.bak` to work around a local environment conflict unrelated to this change
- [ ] After merge: revert `gitRef` to `"main"` once pipestream-protos#31 merges and protos are republished
- [ ] After merge: audit any other repos still importing `ai.pipestream.opensearch.v1.SemanticGranularity` and migrate them to `ai.pipestream.data.v1.GranularityLevel`

## Depends on

- ai-pipestream/pipestream-protos#31 — must merge first (or this PR's CI will fail until the gitRef is resolvable from the published proto branch)