### PR TITLE
feat(opensearch-manager): add VectorSetProvisioner stub

### DIFF
--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/vectorset/NoOpVectorSetProvisioner.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/vectorset/NoOpVectorSetProvisioner.java
@@ -1,0 +1,29 @@
+package ai.pipestream.schemamanager.vectorset;
+
+import ai.pipestream.data.v1.VectorSetDirectives;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * No-op implementation of {@link VectorSetProvisioner}.
+ *
+ * <p>Returns {@code Uni.voidItem()} — does nothing. Field creation on the
+ * target OpenSearch index continues to be handled lazily by
+ * {@code SeparateIndicesIndexingStrategy.ensureFlatKnnField} and
+ * {@code ChunkCombinedIndexingStrategy.ensureFlatKnnField} at indexing
+ * time, with race-safe retry. See {@link VectorSetProvisioner} for the full
+ * explanation.
+ *
+ * <p>TODO task #79: replace this with a real eager-provisioning
+ * implementation that walks {@link VectorSetDirectives} and puts {@code
+ * knn_vector} field mappings on the target index before any documents are
+ * indexed.
+ */
+@ApplicationScoped
+public class NoOpVectorSetProvisioner implements VectorSetProvisioner {
+
+    @Override
+    public Uni<Void> ensureFieldsForDirectives(VectorSetDirectives directives, String indexName) {
+        return Uni.createFrom().voidItem();
+    }
+}

--- a/opensearch-manager/src/main/java/ai/pipestream/schemamanager/vectorset/VectorSetProvisioner.java
+++ b/opensearch-manager/src/main/java/ai/pipestream/schemamanager/vectorset/VectorSetProvisioner.java
@@ -1,0 +1,55 @@
+package ai.pipestream.schemamanager.vectorset;
+
+import ai.pipestream.data.v1.VectorSetDirectives;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Ensures the target OpenSearch index has {@code knn_vector} fields matching
+ * the given {@link VectorSetDirectives}.
+ *
+ * <p>See {@code pipestream-protos/docs/semantic-pipeline/DESIGN.md} §12.2 for
+ * the authoritative spec.
+ *
+ * <p><b>Today (this stub):</b> the only implementation is
+ * {@link NoOpVectorSetProvisioner}, which returns a completed void. The
+ * existing lazy field-creation paths in
+ * {@code SeparateIndicesIndexingStrategy.ensureFlatKnnField} and
+ * {@code ChunkCombinedIndexingStrategy.ensureFlatKnnField} continue to
+ * own {@code knn_vector} field creation at indexing time, with race-safe
+ * retry. This stub is intentionally not wired into any call path — it
+ * exists so a future eager-provisioning implementation (task #79) can be
+ * dropped in without another refactor of call sites.
+ *
+ * <p><b>Future (task #79):</b> a real implementation will walk the
+ * directives, look up (or create) {@link
+ * ai.pipestream.schemamanager.entity.VectorSetEntity} rows for each
+ * {@code NamedEmbedderConfig}, and call the appropriate indexing strategy
+ * to put {@code knn_vector} field mappings on {@code indexName} before any
+ * documents are indexed. That eliminates the first-doc race on lazy field
+ * creation and makes schema evolution explicit.
+ *
+ * <p><b>Why land it now if it does nothing:</b> the semantic pipeline
+ * refactor (DESIGN.md §5 / ROLLOUT.md §6–§8) replaces {@code
+ * module-semantic-manager} with three stateless pipeline-step modules. The
+ * refactor introduces the concept of machine-driven {@code
+ * VectorSetDirectives} on every {@code PipeDoc} entering the chunker. At
+ * some point the directive set on a doc will reference embedder configs
+ * that the target OpenSearch index has never seen before. When that day
+ * comes, we want a well-defined place to preflight the schema. Landing the
+ * interface early means task #79 is a pure binding swap, not a refactor.
+ */
+public interface VectorSetProvisioner {
+
+    /**
+     * Ensures the given OpenSearch index has {@code knn_vector} fields for
+     * every {@code NamedEmbedderConfig} referenced by the given directives.
+     * The no-op implementation returns {@code Uni.voidItem()} — the caller's
+     * downstream indexing code still handles field creation lazily.
+     *
+     * @param directives the {@link VectorSetDirectives} describing the
+     *     vector sets that should exist for the doc about to be indexed
+     * @param indexName the OpenSearch index that will receive the doc
+     * @return a Uni that completes (void) when the fields are ensured
+     */
+    Uni<Void> ensureFieldsForDirectives(VectorSetDirectives directives, String indexName);
+}


### PR DESCRIPTION
## Summary

Second of two Phase 2 supporting stubs for the semantic pipeline refactor (pair to \`ai-pipestream/pipestream-engine#29\` \`DirectivePopulator\` stub). Adds a \`VectorSetProvisioner\` interface + \`NoOpVectorSetProvisioner\` binding in \`opensearch-manager\`. **Intentionally not wired into any call path today** — existing lazy \`ensureFlatKnnField\` still owns \`knn_vector\` field creation at indexing time.

See sibling design docs:
- \`pipestream-protos/docs/semantic-pipeline/DESIGN.md\` §12.2 (interface spec).
- \`pipestream-protos/docs/semantic-pipeline/ROLLOUT.md\` §7.3 (P2b opensearch stub).
- \`pipestream-protos/docs/semantic-pipeline/PLAN.md\` Task 2.3.

## Why now

The semantic pipeline refactor introduces machine-driven \`VectorSetDirectives\` on every \`PipeDoc\` entering the chunker. At some point a doc's directive set will reference embedder configs whose \`knn_vector\` fields don't yet exist on the target OpenSearch index. When that day comes, we want a well-defined **preflight schema hook** instead of continuing to rely solely on the current lazy field-creation path (which works but races with the first doc).

Landing the hook now means the task #79 implementation is a one-binding swap with zero call-site changes. The NoOp binding is trivially safe: \`Uni.createFrom().voidItem()\`.

## What's in this PR

Two files, +84 lines, no modifications to existing code:

- \`opensearch-manager/src/main/java/ai/pipestream/schemamanager/vectorset/VectorSetProvisioner.java\` — interface with one method \`Uni<Void> ensureFieldsForDirectives(VectorSetDirectives directives, String indexName)\`. Javadoc documents today's no-op behavior, why it's not wired in, and the task #79 direction.
- \`opensearch-manager/src/main/java/ai/pipestream/schemamanager/vectorset/NoOpVectorSetProvisioner.java\` — \`@ApplicationScoped\` default implementation returning \`Uni.voidItem()\`.

## Package placement

New subpackage \`ai.pipestream.schemamanager.vectorset\` alongside the existing \`schemamanager.entity\`, \`schemamanager.indexing\`, \`schemamanager.opensearch\`, etc. This is a brand-new empty namespace — **zero split-package risk**. The proto-generated \`VectorSetDirectives\` type this interface imports lives in the disjoint root \`ai.pipestream.data.v1\` (populated exclusively by the proto jar), so the two packages never overlap.

## Why the stub is NOT wired into any call path

Unlike the pair PR in \`pipestream-engine\` (which wires \`DirectivePopulator\` into \`processNodeLogic\` step 1b), this stub has no call-site wiring in this PR. That matches DESIGN.md §12.2 — the existing \`SeparateIndicesIndexingStrategy.ensureFlatKnnField\` and \`ChunkCombinedIndexingStrategy.ensureFlatKnnField\` paths continue to handle field creation lazily, with race-safe retry. Adding a no-op call site now would be pure noise and would need to be re-thought when task #79 lands.

Task #79 will decide where the provisioner call belongs — most likely near the start of an indexing request, after the doc's directives are known but before the first bulk write. That decision is deferred until the real implementation is in scope.

## Test plan

- [x] \`./gradlew :opensearch-manager:compileJava\` — BUILD SUCCESSFUL.
- [x] \`./gradlew :opensearch-manager:test\` — **107 tests, 0 failures, 0 errors, 0 skipped.** No regressions.
- [ ] Reviewer to confirm the package placement (\`ai.pipestream.schemamanager.vectorset\`) matches the repo's subpackage conventions.

## Related

- \`ai-pipestream/pipestream-engine#29\` — pair stub: \`DirectivePopulator\` in the engine.
- \`ai-pipestream/pipestream-platform#51\` — \`SemanticPipelineInvariants\` (merged).
- \`ai-pipestream/pipestream-platform#53\` — wiremock 0.1.55 version bump.
- \`ai-pipestream/pipestream-protos#37\` — ROLLOUT.md / PLAN.md / DESIGN.md §14 (merged).
- \`ai-pipestream/pipestream-wiremock-server#71\` — three step mocks (merged, shipped as 0.1.55).

With this PR, Phase 2 is complete and Phase 3 (three parallel R-agents for chunker / embedder / semantic-graph) becomes unblockable.