### PR TITLE
fix(opensearch-manager): really revert proto gitRef to main (squash-merge dropped it)

### DIFF
--- a/opensearch-manager/build.gradle
+++ b/opensearch-manager/build.gradle
@@ -27,8 +27,7 @@ def pipestreamBomVersion = findProperty('pipestreamBomVersion')
 pipestreamProtos {
     sourceMode = 'git-proto-workspace'
     gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
-    // TODO: revert to "main" after feat/provision-index-rpc merges.
-    gitRef = "feat/provision-index-rpc"
+    gitRef = "main"
 
     modules {
         // Register modules by name only - workspace mode handles cross-module imports


### PR DESCRIPTION
PR #22 was supposed to flip gitRef from `feat/provision-index-rpc` → `main` but the GitHub squash-merge silently kept main's previous value. Cause: PR #21 also touched the same line (set it TO `feat/`), so a 3-way merge saw PR #22's branch tip vs base as 'no change for this line' and kept main's value (which was `feat/`, set by PR #21's earlier squash). Net result: every CI run since #22 still fails fetchProtos because the deleted feature branch is what gets queried. This is a single-line change against current main; no merge-base trickery.